### PR TITLE
Proper fields alignment in `InternalUuidGenerator` struct

### DIFF
--- a/pkg/uuid/internal_generator.go
+++ b/pkg/uuid/internal_generator.go
@@ -35,8 +35,8 @@ type InternalUuidInfo struct {
 
 // InternalUuidGenerator represents internal bundled uuid generator
 type InternalUuidGenerator struct {
-	uuidServerId   uint8
 	uuidSeqNumbers [1 << internalUuidTypeBits]uint64
+	uuidServerId   uint8
 }
 
 // NewInternalUuidGenerator returns a new internal uuid generator


### PR DESCRIPTION
Fixes #14 
`InternalUuidGenerator` struct did not satisfy alignment requirements.

According to atomic package [docs](https://pkg.go.dev/sync/atomic#pkg-note-BUG):

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically via the primitive atomic functions (types Int64 and Uint64 are automatically aligned). The first word in an allocated struct, array, or slice; in a global variable; or in a local variable (because the subject of all atomic operations will escape to the heap) can be relied upon to be 64-bit aligned.

I swapped fields order, now the struct has proper alignment.

Tested on Raspberry Pi 2 Model B