### PR TITLE
Fix replaceAll with special characters

### DIFF
--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -155,7 +155,12 @@ export function getObjectOwnFieldCount(object) {
 }
 
 export function replaceAll(value, originalValue, targetValue) {
-    return value.replaceAll(new RegExp(originalValue, 'g'), targetValue);
+    // Escape special characters in originalValue to safely use it in a regex pattern.
+    // This ensures that characters like . (dot), * (asterisk), +, ?, etc. are treated literally,
+    // rather than as special regex symbols.
+    const escapedOriginalValue = originalValue.replace(/([.*+?^=!:${}()|\-/\\])/g, '\\$1');
+    
+    return value.replaceAll(new RegExp(escapedOriginalValue, 'g'), targetValue);
 }
 
 export function removeAll(value, originalValue) {


### PR DESCRIPTION
In this case, it is because removing the dot from the currency, so it does not work correctly.

Before:


https://github.com/user-attachments/assets/f937923c-f6b5-46eb-9b4d-ce45c77dc739


After:


https://github.com/user-attachments/assets/14a74f7c-f19b-4c6e-88f5-d4e84d3cf645




