### PR TITLE
Fix Spanish translation backend Error

### DIFF
--- a/pkg/locales/es.go
+++ b/pkg/locales/es.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mayswind/ezbookkeeping/pkg/core"
 )
 
-var en = &LocaleTextItems{
+var es = &LocaleTextItems{
 	DefaultTypes: &DefaultTypes{
 		DecimalSeparator:    core.DECIMAL_SEPARATOR_DOT,
 		DigitGroupingSymbol: core.DIGIT_GROUPING_SYMBOL_COMMA,


### PR DESCRIPTION
- Change variable name from "en" to "es" to fix the errors.