### PR TITLE
Feature: 'Fiscal year start' profile setting, allow for date filtering by fiscal year

### DIFF
--- a/cmd/user_data.go
+++ b/cmd/user_data.go
@@ -895,6 +895,7 @@ func printUserInfo(user *models.User) {
 	fmt.Printf("[Language] %s\n", user.Language)
 	fmt.Printf("[DefaultCurrency] %s\n", user.DefaultCurrency)
 	fmt.Printf("[FirstDayOfWeek] %s (%d)\n", user.FirstDayOfWeek, user.FirstDayOfWeek)
+	fmt.Printf("[FiscalYearStart] %s (%d)\n", user.FiscalYearStart, user.FiscalYearStart)
 	fmt.Printf("[LongDateFormat] %s (%d)\n", user.LongDateFormat, user.LongDateFormat)
 	fmt.Printf("[ShortDateFormat] %s (%d)\n", user.ShortDateFormat, user.ShortDateFormat)
 	fmt.Printf("[LongTimeFormat] %s (%d)\n", user.LongTimeFormat, user.LongTimeFormat)

--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -98,6 +98,7 @@ func startWebServer(c *core.CliContext) error {
 		_ = v.RegisterValidation("validCurrency", validators.ValidCurrency)
 		_ = v.RegisterValidation("validHexRGBColor", validators.ValidHexRGBColor)
 		_ = v.RegisterValidation("validAmountFilter", validators.ValidAmountFilter)
+		_ = v.RegisterValidation("validFiscalYearStart", validators.ValidateFiscalYearStart)
 	}
 
 	router.NoRoute(bindApi(api.Default.ApiNotFound))

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,37 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+import type { Config } from 'jest';
+
+const config: Config = {
+
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: false,
+
+  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1"
+  },
+
+  // The test environment that will be used for testing
+  testEnvironment: "node",
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: [
+    "**/__tests__/**/*.[jt]s?(x)",
+    "!**/__tests__/*_gen.[jt]s?(x)"
+  ],
+
+  // A map from regular expressions to paths to transformers
+  transform: {
+    '^.+\\.m?tsx?$': ['ts-jest', { useESM: true, isolatedModules: true }],
+  },
+
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "serve": "cross-env NODE_ENV=development vite",
     "build": "cross-env NODE_ENV=production vite build",
     "serve:dist": "vite preview",
-    "lint": "tsc --noEmit && eslint . --fix"
+    "lint": "tsc --noEmit && eslint . --fix",
+    "test": "jest"
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
@@ -47,10 +48,12 @@
     "vuetify": "^3.7.11"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@tsconfig/node22": "^22.0.0",
     "@types/cbor-js": "^0.1.1",
     "@types/crypto-js": "^4.2.2",
     "@types/git-rev-sync": "^2.0.2",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.12.0",
     "@types/ua-parser-js": "^0.7.39",
     "@vitejs/plugin-vue": "^5.2.1",
@@ -60,8 +63,11 @@
     "eslint": "^9.20.0",
     "eslint-plugin-vue": "^9.32.0",
     "git-rev-sync": "^3.0.2",
+    "jest": "^29.7.0",
     "postcss-preset-env": "^10.1.3",
     "sass": "^1.84.0",
+    "ts-jest": "^29.3.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "vite": "^6.1.0",
     "vite-plugin-pwa": "^0.21.1",

--- a/pkg/api/users.go
+++ b/pkg/api/users.go
@@ -349,6 +349,15 @@ func (a *UsersApi) UserUpdateProfileHandler(c *core.WebContext) (any, *errs.Erro
 		userNew.FirstDayOfWeek = core.WEEKDAY_INVALID
 	}
 
+	if userUpdateReq.FiscalYearStart != nil && *userUpdateReq.FiscalYearStart != user.FiscalYearStart {
+		user.FiscalYearStart = *userUpdateReq.FiscalYearStart
+		userNew.FiscalYearStart = *userUpdateReq.FiscalYearStart
+		modifyProfileBasicInfo = true
+		anythingUpdate = true
+	} else {
+		userNew.FiscalYearStart = core.FISCAL_YEAR_START_INVALID
+	}
+
 	if userUpdateReq.LongDateFormat != nil && *userUpdateReq.LongDateFormat != user.LongDateFormat {
 		user.LongDateFormat = *userUpdateReq.LongDateFormat
 		userNew.LongDateFormat = *userUpdateReq.LongDateFormat

--- a/pkg/core/fiscalyear.go
+++ b/pkg/core/fiscalyear.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/mayswind/ezbookkeeping/pkg/errs"
+)
+
+// FiscalYearStart represents the fiscal year start date as a uint16 (month: high byte, day: low byte)
+type FiscalYearStart uint16
+
+// Fiscal Year Start Date Type
+const (
+	FISCAL_YEAR_START_DEFAULT FiscalYearStart = 0x0101 // January 1
+	FISCAL_YEAR_START_MIN     FiscalYearStart = 0x0101 // January 1
+	FISCAL_YEAR_START_MAX     FiscalYearStart = 0x0C1F // December 31
+	FISCAL_YEAR_START_INVALID FiscalYearStart = 0x0000 // Invalid
+)
+
+// NewFiscalYearStart creates a new FiscalYearStart from month and day values
+func NewFiscalYearStart(month uint8, day uint8) (FiscalYearStart, error) {
+	month, day, err := validateMonthDay(month, day)
+	if err != nil {
+		return 0, err
+	}
+
+	return FiscalYearStart(uint16(month)<<8 | uint16(day)), nil
+}
+
+// GetMonthDay extracts the month and day from FiscalYearType
+func (f FiscalYearStart) GetMonthDay() (uint8, uint8, error) {
+	if f < FISCAL_YEAR_START_MIN || f > FISCAL_YEAR_START_MAX {
+		return 0, 0, errs.ErrFormatInvalid
+	}
+
+	// Extract month and day (month in high byte, day in low byte)
+	month := uint8(f >> 8)
+	day := uint8(f & 0xFF)
+
+	return validateMonthDay(month, day)
+}
+
+// String returns a string representation of FiscalYearStart in MM/DD format
+func (f FiscalYearStart) String() string {
+	month, day, err := f.GetMonthDay()
+	if err != nil {
+		return "Invalid"
+	}
+	return fmt.Sprintf("%02d-%02d", month, day)
+}
+
+// validateMonthDay validates a month and day and returns them if valid
+func validateMonthDay(month uint8, day uint8) (uint8, uint8, error) {
+	if month < 1 || month > 12 || day < 1 {
+		return 0, 0, errs.ErrFormatInvalid
+	}
+
+	maxDays := uint8(31)
+	switch month {
+	case 1, 3, 5, 7, 8, 10, 12: // January, March, May, July, August, October, December
+		maxDays = 31
+	case 4, 6, 9, 11: // April, June, September, November
+		maxDays = 30
+	case 2: // February
+		maxDays = 28 // Disallow fiscal year start on leap day
+	}
+
+	if day > maxDays {
+		return 0, 0, errs.ErrFormatInvalid
+	}
+
+	return month, day, nil
+}

--- a/pkg/core/fiscalyear.go
+++ b/pkg/core/fiscalyear.go
@@ -11,10 +11,10 @@ type FiscalYearStart uint16
 
 // Fiscal Year Start Date Type
 const (
+	FISCAL_YEAR_START_INVALID FiscalYearStart = 0x0000 // Invalid
 	FISCAL_YEAR_START_DEFAULT FiscalYearStart = 0x0101 // January 1
 	FISCAL_YEAR_START_MIN     FiscalYearStart = 0x0101 // January 1
 	FISCAL_YEAR_START_MAX     FiscalYearStart = 0x0C1F // December 31
-	FISCAL_YEAR_START_INVALID FiscalYearStart = 0x0000 // Invalid
 )
 
 // NewFiscalYearStart creates a new FiscalYearStart from month and day values

--- a/pkg/core/fiscalyear_test.go
+++ b/pkg/core/fiscalyear_test.go
@@ -1,0 +1,127 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/mayswind/ezbookkeeping/pkg/errs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFiscalYearStart_ValidMonthDay(t *testing.T) {
+	testCases := []struct {
+		month    uint8
+		day      uint8
+		expected FiscalYearStart
+	}{
+		{1, 1, 0x0101},   // January 1
+		{4, 15, 0x040F},  // April 15
+		{7, 1, 0x0701},   // July 1
+		{12, 31, 0x0C1F}, // December 31
+	}
+
+	for _, tc := range testCases {
+		fiscal, err := NewFiscalYearStart(tc.month, tc.day)
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expected, fiscal)
+	}
+}
+
+func TestNewFiscalYearStart_InvalidMonthDay(t *testing.T) {
+	testCases := []struct {
+		month uint8
+		day   uint8
+	}{
+		{0, 1},    // Month 0 (invalid)
+		{13, 1},   // Month 13 (invalid)
+		{1, 0},    // Day 0 (invalid)
+		{1, 32},   // Day 32 (invalid for January)
+		{2, 30},   // Day 30 (invalid for February)
+		{2, 29},   // Day 29 (leap day not permitted)
+		{4, 31},   // Day 31 (invalid for April)
+		{6, 31},   // Day 31 (invalid for June)
+		{9, 31},   // Day 31 (invalid for September)
+		{11, 32},  // Day 32 (invalid for November)
+		{255, 15}, // Invalid month
+		{5, 255},  // Invalid day
+	}
+
+	for _, tc := range testCases {
+		fiscal, err := NewFiscalYearStart(tc.month, tc.day)
+		assert.Equal(t, FiscalYearStart(0), fiscal)
+		assert.Equal(t, errs.ErrFormatInvalid, err)
+	}
+}
+
+func TestGetMonthDay_ValidFiscalYearStart(t *testing.T) {
+	testCases := []struct {
+		fiscalYear FiscalYearStart
+		month      uint8
+		day        uint8
+	}{
+		{0x0101, 1, 1},   // January 1st
+		{0x0C1F, 12, 31}, // December 31st
+		{0x0701, 7, 1},   // July 1st
+		{0x040F, 4, 15},  // April 15th
+	}
+
+	for _, tc := range testCases {
+		month, day, err := tc.fiscalYear.GetMonthDay()
+		assert.Nil(t, err)
+		assert.Equal(t, tc.month, month)
+		assert.Equal(t, tc.day, day)
+	}
+}
+
+func TestGetMonthDay_InvalidFiscalYearStart(t *testing.T) {
+	testCases := []struct {
+		fiscalYear FiscalYearStart
+	}{
+		{0x0000}, // 0/0 (invalid)
+		{0x0D01}, // Month 13 (invalid)
+		{0x0100}, // Day 0 (invalid)
+		{0x0120}, // January 32 (invalid)
+		{0x021D}, // February 29 (not permitted)
+		{0x021E}, // February 30 (invalid)
+		{0x041F}, // April 31 (invalid)
+		{0x061F}, // June 31 (invalid)
+		{0x091F}, // September 31 (invalid)
+		{0x0B20}, // November 32 (invalid)
+		{0xFF01}, // Invalid month
+		{0x01FF}, // Invalid day
+		{0},      // Zero value
+	}
+
+	for _, tc := range testCases {
+		month, day, err := tc.fiscalYear.GetMonthDay()
+		assert.Equal(t, uint8(0), month)
+		assert.Equal(t, uint8(0), day)
+		assert.Equal(t, errs.ErrFormatInvalid, err)
+	}
+}
+
+func TestFiscalYearStart_String(t *testing.T) {
+	testCases := []struct {
+		fiscalYear FiscalYearStart
+		expected   string
+	}{
+		{0x0101, "01-01"},   // January 1st
+		{0x0C1F, "12-31"},   // December 31st
+		{0x0701, "07-01"},   // July 1st
+		{0x040F, "04-15"},   // April 15th
+		{0x021D, "Invalid"}, // February 29th (leap day not permitted)
+		{0x0000, "Invalid"}, // Invalid date
+		{0x0D01, "Invalid"}, // Invalid month
+		{0x0120, "Invalid"}, // Invalid day
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, tc.fiscalYear.String())
+	}
+}
+
+func TestFiscalYearStartConstants(t *testing.T) {
+	assert.Equal(t, FiscalYearStart(0x0000), FISCAL_YEAR_START_INVALID)
+	assert.Equal(t, FiscalYearStart(0x0101), FISCAL_YEAR_START_DEFAULT)
+	assert.Equal(t, FiscalYearStart(0x0101), FISCAL_YEAR_START_MIN)
+	assert.Equal(t, FiscalYearStart(0x0C1F), FISCAL_YEAR_START_MAX)
+}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -94,6 +94,7 @@ type User struct {
 	Language             string                   `xorm:"VARCHAR(10)"`
 	DefaultCurrency      string                   `xorm:"VARCHAR(3) NOT NULL"`
 	FirstDayOfWeek       core.WeekDay             `xorm:"TINYINT NOT NULL"`
+	FiscalYearStart      core.FiscalYearStart     `xorm:"SMALLINT"`
 	LongDateFormat       core.LongDateFormat      `xorm:"TINYINT"`
 	ShortDateFormat      core.ShortDateFormat     `xorm:"TINYINT"`
 	LongTimeFormat       core.LongTimeFormat      `xorm:"TINYINT"`
@@ -126,6 +127,7 @@ type UserBasicInfo struct {
 	Language             string                   `json:"language"`
 	DefaultCurrency      string                   `json:"defaultCurrency"`
 	FirstDayOfWeek       core.WeekDay             `json:"firstDayOfWeek"`
+	FiscalYearStart      core.FiscalYearStart     `json:"fiscalYearStart"`
 	LongDateFormat       core.LongDateFormat      `json:"longDateFormat"`
 	ShortDateFormat      core.ShortDateFormat     `json:"shortDateFormat"`
 	LongTimeFormat       core.LongTimeFormat      `json:"longTimeFormat"`
@@ -186,6 +188,7 @@ type UserProfileUpdateRequest struct {
 	Language             string                    `json:"language" binding:"omitempty,min=2,max=16"`
 	DefaultCurrency      string                    `json:"defaultCurrency" binding:"omitempty,len=3,validCurrency"`
 	FirstDayOfWeek       *core.WeekDay             `json:"firstDayOfWeek" binding:"omitempty,min=0,max=6"`
+	FiscalYearStart      *core.FiscalYearStart     `json:"fiscalYearStart" binding:"omitempty,validFiscalYearStart"`
 	LongDateFormat       *core.LongDateFormat      `json:"longDateFormat" binding:"omitempty,min=0,max=3"`
 	ShortDateFormat      *core.ShortDateFormat     `json:"shortDateFormat" binding:"omitempty,min=0,max=3"`
 	LongTimeFormat       *core.LongTimeFormat      `json:"longTimeFormat" binding:"omitempty,min=0,max=3"`
@@ -265,6 +268,7 @@ func (u *User) ToUserBasicInfo(avatarProvider core.UserAvatarProviderType, avata
 		Language:             u.Language,
 		DefaultCurrency:      u.DefaultCurrency,
 		FirstDayOfWeek:       u.FirstDayOfWeek,
+		FiscalYearStart:      u.FiscalYearStart,
 		LongDateFormat:       u.LongDateFormat,
 		ShortDateFormat:      u.ShortDateFormat,
 		LongTimeFormat:       u.LongTimeFormat,

--- a/pkg/services/users.go
+++ b/pkg/services/users.go
@@ -289,6 +289,10 @@ func (s *UserService) UpdateUser(c core.Context, user *models.User, modifyUserLa
 		updateCols = append(updateCols, "first_day_of_week")
 	}
 
+	if core.FISCAL_YEAR_START_DEFAULT <= user.FiscalYearStart && core.FISCAL_YEAR_START_MIN <= user.FiscalYearStart && core.FISCAL_YEAR_START_MAX >= user.FiscalYearStart {
+		updateCols = append(updateCols, "fiscal_year_start")
+	}
+
 	if core.LONG_DATE_FORMAT_DEFAULT <= user.LongDateFormat && user.LongDateFormat <= core.LONG_DATE_FORMAT_D_M_YYYY {
 		updateCols = append(updateCols, "long_date_format")
 	}

--- a/pkg/validators/fiscal_year_start_date.go
+++ b/pkg/validators/fiscal_year_start_date.go
@@ -1,0 +1,26 @@
+package validators
+
+import (
+	"github.com/gin-gonic/gin/binding"
+	"github.com/go-playground/validator/v10"
+	"github.com/mayswind/ezbookkeeping/pkg/core"
+)
+
+// ValidateFiscalYearStart validates if a fiscal year start date is valid
+func ValidateFiscalYearStart(fl validator.FieldLevel) bool {
+	date, ok := fl.Field().Interface().(core.FiscalYearStart)
+	if !ok {
+		return false
+	}
+
+	// Use the core functionality to validate
+	_, _, err := date.GetMonthDay()
+	return err == nil
+}
+
+// RegisterFiscalYearStartValidator registers the fiscal year start date validator
+func RegisterFiscalYearStartValidator() {
+	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
+		v.RegisterValidation("validFiscalYearStart", ValidateFiscalYearStart)
+	}
+}

--- a/pkg/validators/fiscal_year_start_date_test.go
+++ b/pkg/validators/fiscal_year_start_date_test.go
@@ -1,0 +1,68 @@
+package validators
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/mayswind/ezbookkeeping/pkg/core"
+	"github.com/stretchr/testify/assert"
+)
+
+type fiscalYearStartContainer struct {
+	FiscalYearStart core.FiscalYearStart `validate:"validFiscalYearStart"`
+}
+
+func TestValidateFiscalYearStart_ValidValues(t *testing.T) {
+	validate := validator.New()
+	validate.RegisterValidation("validFiscalYearStart", ValidateFiscalYearStart)
+
+	testCases := []struct {
+		name  string
+		value core.FiscalYearStart
+	}{
+		{"January 1", 0x0101},   // January 1
+		{"December 31", 0x0C1F}, // December 31
+		{"July 1", 0x0701},      // July 1
+		{"April 15", 0x040F},    // April 15
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			container := fiscalYearStartContainer{FiscalYearStart: tc.value}
+			err := validate.Struct(container)
+			assert.Nil(t, err)
+		})
+	}
+}
+
+func TestValidateFiscalYearStart_InvalidValues(t *testing.T) {
+	validate := validator.New()
+	validate.RegisterValidation("validFiscalYearStart", ValidateFiscalYearStart)
+
+	testCases := []struct {
+		name  string
+		value core.FiscalYearStart
+	}{
+		{"Zero value", 0},             // Zero value
+		{"Month 0", 0x0001},           // Month 0 (invalid)
+		{"Month 13", 0x0D01},          // Month 13 (invalid)
+		{"Day 0", 0x0100},             // Day 0 (invalid)
+		{"January 32", 0x0120},        // January 32 (invalid)
+		{"February 29", 0x021D},       // February 29 (not permitted)
+		{"February 30", 0x021E},       // February 30 (invalid)
+		{"April 31", 0x041F},          // April 31 (invalid)
+		{"June 31", 0x061F},           // June 31 (invalid)
+		{"September 31", 0x091F},      // September 31 (invalid)
+		{"November 32", 0x0B20},       // November 32 (invalid)
+		{"Invalid month 255", 0xFF01}, // Invalid month
+		{"Invalid day 255", 0x01FF},   // Invalid day
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			container := fiscalYearStartContainer{FiscalYearStart: tc.value}
+			err := validate.Struct(container)
+			assert.NotNil(t, err)
+		})
+	}
+}

--- a/src/components/base/FiscalYearStartSelectionBase.ts
+++ b/src/components/base/FiscalYearStartSelectionBase.ts
@@ -1,0 +1,111 @@
+import { computed } from 'vue';
+
+import { FiscalYearStart } from '@/core/fiscalyear.ts';
+
+import { useI18n } from '@/locales/helpers.ts';
+
+import { formatMonthDay } from '@/lib/datetime.ts';
+
+import { useUserStore } from '@/stores/user.ts';
+
+export interface FiscalYearStartSelectionBaseProps {
+    modelValue?: number;
+}
+
+export interface FiscalYearStartSelectionBaseEmits {
+    (e: 'update:modelValue', value: number): void;
+}
+
+export function useFiscalYearStartSelectionBase(props: FiscalYearStartSelectionBaseProps, emit?: FiscalYearStartSelectionBaseEmits) {
+    const { getCurrentFiscalYearStart, getLocalizedLongMonthDayFormat } = useI18n();
+    const userStore = useUserStore();
+
+    const getDefaultValue = (): number => {
+        return userStore.currentUserFiscalYearStart || FiscalYearStart.DefaultNumber;
+    };
+
+    const effectiveModelValue = computed<number>(() => {
+        return props.modelValue !== undefined ? props.modelValue : getDefaultValue();
+    });
+
+    function getterModelValue(input?: number): string {
+        const valueToUse = input !== undefined ? input : effectiveModelValue.value;
+        
+        if (valueToUse !== 0 && valueToUse !== undefined) {
+            const fy = FiscalYearStart.fromNumber(valueToUse);
+            if (fy) {
+                return fy.toMonthDashDayString();
+            }
+        }
+        return getCurrentFiscalYearStart().toMonthDashDayString();
+    }
+
+    function setterModelValue(input: string): number {
+        const fy = FiscalYearStart.fromMonthDashDayString(input);
+        if (fy) {
+            return fy.toNumber();
+        }
+        return getCurrentFiscalYearStart().toNumber();
+    }
+    
+    const displayName = computed<string>(() => {
+        let fy = getCurrentFiscalYearStart();
+
+        if (effectiveModelValue.value !== 0 && effectiveModelValue.value !== undefined) {
+            const testFy = FiscalYearStart.fromNumber(effectiveModelValue.value);
+            if (testFy) {
+                fy = testFy;
+            }
+        }
+        
+        const monthDay = fy.toMonthDashDayString();
+        return formatMonthDay(
+            monthDay,
+            getLocalizedLongMonthDayFormat(),
+        );
+    });
+
+    const disabledDates = (date: Date) => {
+        // Disable February 29 (leap day)
+        return date.getMonth() === 1 && date.getDate() === 29; 
+    };
+
+    const selectedDate = computed<string>({
+        get: () => getterModelValue(),
+        set: (value: string) => {
+            if (emit) {
+                const numericValue = setterModelValue(value);
+                emit('update:modelValue', numericValue);
+            }
+        }
+    });
+
+    const initializeWithDefaultValue = () => {
+        if (emit && props.modelValue === undefined) {
+            emit('update:modelValue', getDefaultValue());
+        }
+    };
+
+    return {
+        // computed states
+        displayName,
+        disabledDates,
+        effectiveModelValue,
+        selectedDate,
+        // functions
+        getterModelValue,
+        setterModelValue,
+        initializeWithDefaultValue,
+        getDefaultValue
+    }
+}
+
+
+
+//toUIDate(input: number): string {
+//return FiscalYearStart.fromUint16(input).toMonthDashDayString();
+//}
+//
+//toUserProfileFormat(input: string): number {
+//return FiscalYearStart.fromMonthDashDayString(input).toUint16();
+//}

--- a/src/components/desktop/FiscalYearStartSelect.vue
+++ b/src/components/desktop/FiscalYearStartSelect.vue
@@ -1,0 +1,92 @@
+<template>
+    <v-select
+        persistent-placeholder
+        :readonly="readonly"
+        :disabled="disabled"
+        :clearable="modelValue ? clearable : false"
+        :label="label"
+        :menu-props="{ contentClass: 'date-select-menu' }"
+        v-model="selectedDate"
+    >
+        <template #selection>
+            <span class="text-truncate cursor-pointer">{{ displayName }}</span>
+        </template>
+
+        <template #no-data>
+            <vue-date-picker inline vertical auto-apply hide-offset-dates disable-year-select
+                             ref="datepicker"
+                             month-name-format="long"
+                             model-type="MM-dd"
+                             :clearable="false"
+                             :enable-time-picker="false"
+                             :dark="isDarkMode"
+                             :week-start="firstDayOfWeek"
+                             :day-names="dayNames"
+                             :disabled-dates="disabledDates"
+                             v-model="selectedDate"
+                             >
+                <template #month="{ text }">
+                    {{ getMonthShortName(text) }}
+                </template>
+                <template #month-overlay-value="{ text }">
+                    {{ getMonthShortName(text) }}
+                </template>
+            </vue-date-picker>
+        </template>
+    </v-select>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue';
+import { useTheme } from 'vuetify';
+import { useUserStore } from '@/stores/user.ts';
+import { ThemeType } from '@/core/theme.ts';
+import { arrangeArrayWithNewStartIndex } from '@/lib/common.ts';
+import {
+    type FiscalYearStartSelectionBaseProps,
+    type FiscalYearStartSelectionBaseEmits,
+    useFiscalYearStartSelectionBase
+} from '@/components/base/FiscalYearStartSelectionBase.ts';
+import { useI18n } from '@/locales/helpers.ts';
+
+interface FiscalYearStartSelectProps extends FiscalYearStartSelectionBaseProps {
+    disabled?: boolean;
+    readonly?: boolean;
+    clearable?: boolean;
+    label?: string;
+}
+
+const props = defineProps<FiscalYearStartSelectProps>();
+const emit = defineEmits<FiscalYearStartSelectionBaseEmits>();
+
+const { getAllMinWeekdayNames, getMonthShortName } = useI18n();
+const userStore = useUserStore();
+const theme = useTheme();
+
+const isDarkMode = computed<boolean>(() => theme.global.name.value === ThemeType.Dark);
+const firstDayOfWeek = computed<number>(() => userStore.currentUserFirstDayOfWeek);
+const dayNames = computed<string[]>(() => arrangeArrayWithNewStartIndex(getAllMinWeekdayNames(), firstDayOfWeek.value));
+
+// Get all base functionality
+const {
+    displayName,
+    disabledDates,
+    selectedDate,
+    initializeWithDefaultValue
+} = useFiscalYearStartSelectionBase(props, emit);
+
+// Initialize the component with the correct value
+onMounted(() => {
+    initializeWithDefaultValue();
+});
+</script>
+
+<style>
+.date-select-menu {
+    max-height: inherit !important;
+}
+
+.date-select-menu .dp__menu {
+    border: 0;
+}
+</style>

--- a/src/core/fiscalyear.ts
+++ b/src/core/fiscalyear.ts
@@ -1,0 +1,211 @@
+import type { TypeAndName } from './base.ts';
+
+export class FiscalYearStart implements TypeAndName {
+    public static readonly DefaultNumber = 0x0101;
+    public static readonly DefaultString = "01-01";
+    public static readonly Default = new FiscalYearStart(1, 1);
+
+    public readonly type: number;
+    public readonly name: string;
+    
+    private readonly month: number;
+    private readonly day: number;
+    
+    public get Month(): number { return this.month; }
+    public get Day(): number { return this.day; }
+
+    private constructor(month: number, day: number) {
+        const [validMonth, validDay] = validateMonthDay(month, day);
+        this.month = validMonth;
+        this.day = validDay;
+        this.type = (validMonth << 8) | validDay;
+        
+        this.name = `Y-${month}-${day}`;
+    }
+
+    public static of(month: number, day: number): FiscalYearStart {
+        return new FiscalYearStart(month, day);
+    }
+
+    public static valueOf(type: number): FiscalYearStart {
+        return FiscalYearStart.strictFromNumber(type);
+    }
+
+    public static valuesFromNumber(type: number): number[] {
+        return FiscalYearStart.strictFromNumber(type).values();
+    }
+
+    public values(): number[] {
+        return [
+            this.month,
+            this.day
+        ];
+    }
+
+    public static parse(typeName: string): FiscalYearStart | undefined {
+        return FiscalYearStart.strictFromMonthDashDayString(typeName);
+    }
+
+    public static isValidType(type: number): boolean {
+        if (type < 0x0101 || type > 0x1231) {
+            return false;
+        }
+        
+        const month = (type >> 8) & 0xFF;
+        const day = type & 0xFF;
+        
+        try {
+            validateMonthDay(month, day);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    public isValid(): boolean {
+        try {
+            FiscalYearStart.validateMonthDay(this.month, this.day);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    public isDefault(): boolean {
+        return this.month === 1 && this.day === 1;
+    }
+
+    public static validateMonthDay(month: number, day: number): [number, number] {
+        return validateMonthDay(month, day);
+    }
+
+    public static strictFromMonthDayValues(month: number, day: number): FiscalYearStart {
+        return FiscalYearStart.of(month, day);
+    }
+
+    /**
+     * Create a FiscalYearStart from a uint16 value (two bytes - month high, day low)
+     * @param value uint16 value (month in high byte, day in low byte)
+     * @returns FiscalYearStart instance
+     */
+    public static strictFromNumber(value: number): FiscalYearStart {
+        if (value < 0 || value > 0xFFFF) {
+            throw new Error("Invalid uint16 value");
+        }
+
+        const month = (value >> 8) & 0xFF;  // high byte
+        const day = value & 0xFF;           // low byte
+
+        try {
+            const [validMonth, validDay] = validateMonthDay(month, day);
+            return FiscalYearStart.of(validMonth, validDay);
+        } catch (error) {
+            throw new Error("Invalid uint16 value");
+        }
+    }
+
+    /**
+     * Create a FiscalYearStart from a month/day string
+     * @param input MM-dd string (e.g. "04-01" = 1 April)
+     * @returns FiscalYearStart instance
+     */
+    public static strictFromMonthDashDayString(input: string): FiscalYearStart {
+        if (!input || !input.includes('-')) {
+            throw new Error("Invalid input string");
+        }
+
+        const parts = input.split('-');
+        if (parts.length !== 2) {
+            throw new Error("Invalid input string");
+        }
+
+        const month = parseInt(parts[0], 10);
+        const day = parseInt(parts[1], 10);
+
+        if (isNaN(month) || isNaN(day)) {
+            throw new Error("Invalid input string");
+        }
+
+        try {
+            const [validMonth, validDay] = validateMonthDay(month, day);
+            return FiscalYearStart.of(validMonth, validDay);
+        } catch (error) {
+            throw new Error("Invalid input string");
+        }
+    }
+
+    public static fromMonthDashDayString(input: string): FiscalYearStart | null {
+        try {
+            return FiscalYearStart.strictFromMonthDashDayString(input);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    public static fromNumber(value: number): FiscalYearStart | null {
+        try {
+            return FiscalYearStart.strictFromNumber(value);
+        } catch (error) {
+            return null;
+        }
+    }
+
+    public static fromMonthDayValues(month: number, day: number): FiscalYearStart | null {
+        try {
+            return FiscalYearStart.strictFromMonthDayValues(month, day);
+        } catch (error) {
+            return null;
+        }
+    }
+    
+    /**
+     * Convert to a uint16 value (two bytes - month high, day low)
+     * @returns uint16 value (month in high byte, day in low byte)
+     */
+    public toNumber(): number {
+        return this.type;
+    }
+
+    public toMonthDashDayString(): string {
+        return `${this.month.toString().padStart(2, '0')}-${this.day.toString().padStart(2, '0')}`;
+    }
+
+    public toMonthDayValues(): [string, string] {
+        return [
+            `${this.month.toString().padStart(2, '0')}`,
+            `${this.day.toString().padStart(2, '0')}`
+        ]
+    }
+
+    public toString(): string {
+        return this.toMonthDashDayString();
+    }
+}
+
+function validateMonthDay(month: number, day: number): [number, number] {
+    if (month < 1 || month > 12 || day < 1) {
+        throw new Error("Invalid month or day");
+    }
+
+    let maxDays = 31;
+    switch (month) {
+        // January, March, May, July, August, October, December
+        case 1: case 3: case 5: case 7: case 8: case 10: case 12: 
+            maxDays = 31;
+            break;
+        // April, June, September, November
+        case 4: case 6: case 9: case 11: 
+            maxDays = 30;
+            break;
+        // February
+        case 2: 
+            maxDays = 28; // Disallow fiscal year start on leap day
+            break;
+    }
+
+    if (day > maxDays) {
+        throw new Error("Invalid day for given month");
+    }
+
+    return [month, day];
+}

--- a/src/desktop-main.ts
+++ b/src/desktop-main.ts
@@ -83,6 +83,7 @@ import LanguageSelectButton from '@/components/desktop/LanguageSelectButton.vue'
 import CurrencySelect from '@/components/desktop/CurrencySelect.vue';
 import DateTimeSelect from '@/components/desktop/DateTimeSelect.vue';
 import DateSelect from '@/components/desktop/DateSelect.vue';
+import FiscalYearStartSelect from '@/components/desktop/FiscalYearStartSelect.vue';
 import ColorSelect from '@/components/desktop/ColorSelect.vue';
 import IconSelect from '@/components/desktop/IconSelect.vue';
 import TwoColumnSelect from '@/components/desktop/TwoColumnSelect.vue';
@@ -458,6 +459,7 @@ app.component('LanguageSelectButton', LanguageSelectButton);
 app.component('CurrencySelect', CurrencySelect);
 app.component('DateTimeSelect', DateTimeSelect);
 app.component('DateSelect', DateSelect);
+app.component('FiscalYearStartSelect', FiscalYearStartSelect);
 app.component('ColorSelect', ColorSelect);
 app.component('IconSelect', IconSelect);
 app.component('TwoColumnSelect', TwoColumnSelect);

--- a/src/lib/__tests__/fiscalyear.data.json
+++ b/src/lib/__tests__/fiscalyear.data.json
@@ -1,0 +1,1498 @@
+{
+    "test_cases_getFiscalYearFromUnixTime": [
+        {
+            "date": "2022-01-01",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2022,
+                "October 1": 2022
+            }
+        },
+        {
+            "date": "2022-03-31",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2022,
+                "October 1": 2022
+            }
+        },
+        {
+            "date": "2022-04-01",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2023,
+                "October 1": 2022
+            }
+        },
+        {
+            "date": "2022-09-30",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2023,
+                "October 1": 2022
+            }
+        },
+        {
+            "date": "2022-10-01",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2023,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2022-12-31",
+            "expected": {
+                "January 1": 2022,
+                "April 1": 2023,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2023-01-01",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2023,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2023-03-31",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2023,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2023-04-01",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2024,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2023-09-30",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2024,
+                "October 1": 2023
+            }
+        },
+        {
+            "date": "2023-10-01",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2024,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2023-12-31",
+            "expected": {
+                "January 1": 2023,
+                "April 1": 2024,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2024-01-01",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2024,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2024-03-31",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2024,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2024-04-01",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2025,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2024-09-30",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2025,
+                "October 1": 2024
+            }
+        },
+        {
+            "date": "2024-10-01",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2025,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2024-12-31",
+            "expected": {
+                "January 1": 2024,
+                "April 1": 2025,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2025-01-01",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2025,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2025-03-31",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2025,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2025-04-01",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2026,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2025-09-30",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2026,
+                "October 1": 2025
+            }
+        },
+        {
+            "date": "2025-10-01",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2026,
+                "October 1": 2026
+            }
+        },
+        {
+            "date": "2025-12-31",
+            "expected": {
+                "January 1": 2025,
+                "April 1": 2026,
+                "October 1": 2026
+            }
+        }
+    ],
+    "test_cases_getFiscalYearStartUnixTime": [
+        {
+            "date": "2022-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1617235200,
+                    "unixTimeISO": "2021-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1633046400,
+                    "unixTimeISO": "2021-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2022-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1617235200,
+                    "unixTimeISO": "2021-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1633046400,
+                    "unixTimeISO": "2021-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2022-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1633046400,
+                    "unixTimeISO": "2021-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2022-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1633046400,
+                    "unixTimeISO": "2021-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2022-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2022-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1640995200,
+                    "unixTimeISO": "2022-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771200,
+                    "unixTimeISO": "2022-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582400,
+                    "unixTimeISO": "2022-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2023-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531200,
+                    "unixTimeISO": "2023-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307200,
+                    "unixTimeISO": "2023-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118400,
+                    "unixTimeISO": "2023-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2024-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067200,
+                    "unixTimeISO": "2024-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929600,
+                    "unixTimeISO": "2024-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465600,
+                    "unixTimeISO": "2025-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465600,
+                    "unixTimeISO": "2025-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740800,
+                    "unixTimeISO": "2024-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465600,
+                    "unixTimeISO": "2025-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276800,
+                    "unixTimeISO": "2025-10-01T00:00:00Z"
+                }
+            }
+        },
+        {
+            "date": "2025-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689600,
+                    "unixTimeISO": "2025-01-01T00:00:00Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465600,
+                    "unixTimeISO": "2025-04-01T00:00:00Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276800,
+                    "unixTimeISO": "2025-10-01T00:00:00Z"
+                }
+            }
+        }
+    ],
+    "test_cases_getFiscalYearEndUnixTime": [
+        {
+            "date": "2022-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771199,
+                    "unixTimeISO": "2022-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582399,
+                    "unixTimeISO": "2022-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2022-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1648771199,
+                    "unixTimeISO": "2022-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582399,
+                    "unixTimeISO": "2022-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2022-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582399,
+                    "unixTimeISO": "2022-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2022-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1664582399,
+                    "unixTimeISO": "2022-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2022-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2022-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1672531199,
+                    "unixTimeISO": "2022-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1680307199,
+                    "unixTimeISO": "2023-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1696118399,
+                    "unixTimeISO": "2023-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2023-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1704067199,
+                    "unixTimeISO": "2023-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1711929599,
+                    "unixTimeISO": "2024-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1727740799,
+                    "unixTimeISO": "2024-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2024-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1735689599,
+                    "unixTimeISO": "2024-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-01-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-03-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1743465599,
+                    "unixTimeISO": "2025-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-04-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1775001599,
+                    "unixTimeISO": "2026-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-09-30",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1775001599,
+                    "unixTimeISO": "2026-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1759276799,
+                    "unixTimeISO": "2025-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-10-01",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1775001599,
+                    "unixTimeISO": "2026-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1790812799,
+                    "unixTimeISO": "2026-09-30T23:59:59Z"
+                }
+            }
+        },
+        {
+            "date": "2025-12-31",
+            "expected": {
+                "January 1": {
+                    "unixTime": 1767225599,
+                    "unixTimeISO": "2025-12-31T23:59:59Z"
+                },
+                "April 1": {
+                    "unixTime": 1775001599,
+                    "unixTimeISO": "2026-03-31T23:59:59Z"
+                },
+                "October 1": {
+                    "unixTime": 1790812799,
+                    "unixTimeISO": "2026-09-30T23:59:59Z"
+                }
+            }
+        }
+    ],
+    "test_cases_getFiscalYearUnixTimeRange": [
+        {
+            "date": "2022-01-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1617235200,
+                    "maxUnixTime": 1648771199
+                },
+                "October 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1633046400,
+                    "maxUnixTime": 1664582399
+                }
+            }
+        },
+        {
+            "date": "2022-03-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1617235200,
+                    "maxUnixTime": 1648771199
+                },
+                "October 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1633046400,
+                    "maxUnixTime": 1664582399
+                }
+            }
+        },
+        {
+            "date": "2022-04-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1633046400,
+                    "maxUnixTime": 1664582399
+                }
+            }
+        },
+        {
+            "date": "2022-09-30",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1633046400,
+                    "maxUnixTime": 1664582399
+                }
+            }
+        },
+        {
+            "date": "2022-10-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2022-12-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2022,
+                    "minUnixTime": 1640995200,
+                    "maxUnixTime": 1672531199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2023-01-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2023-03-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1648771200,
+                    "maxUnixTime": 1680307199
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2023-04-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2023-09-30",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1664582400,
+                    "maxUnixTime": 1696118399
+                }
+            }
+        },
+        {
+            "date": "2023-10-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2023-12-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2023,
+                    "minUnixTime": 1672531200,
+                    "maxUnixTime": 1704067199
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2024-01-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2024-03-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1680307200,
+                    "maxUnixTime": 1711929599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2024-04-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2024-09-30",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1696118400,
+                    "maxUnixTime": 1727740799
+                }
+            }
+        },
+        {
+            "date": "2024-10-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2024-12-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2024,
+                    "minUnixTime": 1704067200,
+                    "maxUnixTime": 1735689599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2025-01-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2025-03-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1711929600,
+                    "maxUnixTime": 1743465599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2025-04-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1743465600,
+                    "maxUnixTime": 1775001599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2025-09-30",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1743465600,
+                    "maxUnixTime": 1775001599
+                },
+                "October 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1727740800,
+                    "maxUnixTime": 1759276799
+                }
+            }
+        },
+        {
+            "date": "2025-10-01",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1743465600,
+                    "maxUnixTime": 1775001599
+                },
+                "October 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1759276800,
+                    "maxUnixTime": 1790812799
+                }
+            }
+        },
+        {
+            "date": "2025-12-31",
+            "expected": {
+                "January 1": {
+                    "fiscalYear": 2025,
+                    "minUnixTime": 1735689600,
+                    "maxUnixTime": 1767225599
+                },
+                "April 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1743465600,
+                    "maxUnixTime": 1775001599
+                },
+                "October 1": {
+                    "fiscalYear": 2026,
+                    "minUnixTime": 1759276800,
+                    "maxUnixTime": 1790812799
+                }
+            }
+        }
+    ]
+}

--- a/src/lib/__tests__/fiscalyear.ts
+++ b/src/lib/__tests__/fiscalyear.ts
@@ -1,0 +1,232 @@
+// Unit tests for fiscal year functions
+import moment from 'moment-timezone';
+import { describe, expect, test, beforeAll } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+// Import all the fiscal year functions from the lib
+import {
+    getFiscalYearFromUnixTime,
+    getFiscalYearStartUnixTime,
+    getFiscalYearEndUnixTime,
+    getFiscalYearUnixTimeRange
+} from '@/lib/fiscalyear.ts';
+
+import { formatUnixTime } from '@/lib/datetime.ts';
+import { FiscalYearStart } from '@/core/fiscalyear.ts';
+
+// Set test environment timezone to UTC, since the test data constants are in UTC
+beforeAll(() => {
+    moment.tz.setDefault('UTC');
+});
+
+// UTILITIES
+
+function importTestData(datasetName: string): any[] {
+    const data = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fiscalyear.data.json'), 'utf8')
+    );
+    if (!data || typeof data[datasetName] === 'undefined') {
+        throw new Error(`${datasetName} is undefined or missing in the data object.`);
+    }
+    return data[datasetName];
+}
+
+function formatUnixTimeISO(unixTime: number): string {
+    return formatUnixTime(unixTime, 'YYYY-MM-DD[T]HH:mm:ss[Z]');
+}
+
+function getTestTitleFormat(testFiscalYearStartId: string, testCaseDateString: string): string {
+    return `FY_START: ${testFiscalYearStartId.padStart(10, ' ')}; DATE: ${moment(testCaseDateString).format('MMMM D, YYYY')}`;
+}
+
+// FISCAL YEAR START CONFIGURATION
+type FiscalYearStartConfig = {
+    id: string;
+    monthDateString: string;
+    value: number;
+};
+
+const TEST_FISCAL_YEAR_START_PRESETS: Record<string, FiscalYearStartConfig> = {
+    'January 1': {
+        id: 'January 1',
+        monthDateString: '01-01',
+        value: 0x0101,
+    },
+    'April 1': {
+        id: 'April 1',
+        monthDateString: '04-01',
+        value: 0x0401,
+    },
+    'October 1': {
+        id: 'October 1',
+        monthDateString: '10-01',
+        value: 0x0A01,
+    },
+};
+
+// VALIDATE FISCAL YEAR START PRESETS
+describe('validateFiscalYearStart', () => {
+    Object.values(TEST_FISCAL_YEAR_START_PRESETS).forEach((testFiscalYearStart) => {
+        test(`should return true if fiscal year start value (uint16) is valid: id: ${testFiscalYearStart.id}; value: 0x${testFiscalYearStart.value.toString(16)}`, () => {
+            expect(FiscalYearStart.isValidType(testFiscalYearStart.value)).toBe(true);
+        });
+
+        test(`returns same month-date string for valid fiscal year start value: id: ${testFiscalYearStart.id}; value: 0x${testFiscalYearStart.value.toString(16)}`, () => {
+            const fiscalYearStart = FiscalYearStart.strictFromNumber(testFiscalYearStart.value);
+            expect(fiscalYearStart.toString()).toStrictEqual(testFiscalYearStart.monthDateString);
+        });
+    });
+});
+
+
+// VALIDATE INVALID FISCAL YEAR START VALUES
+const TestCase_invalidFiscalYearValues = [
+    0x0000, // Invalid: L0/0
+    0x0D01, // Invalid: Month 13
+    0x0100, // Invalid: Day 0
+    0x0120, // Invalid: January 32
+    0x021D, // Invalid: February 29 (not permitted)
+    0x021E, // Invalid: February 30
+    0x041F, // Invalid: April 31
+    0x061F, // Invalid: June 31
+    0x091F, // Invalid: September 31
+    0x0B20, // Invalid: November 32
+    0xFFFF, // Invalid: Largest uint16
+]
+
+describe('validateFiscalYearStartInvalidValues', () => {
+    TestCase_invalidFiscalYearValues.forEach((testCase) => {
+        test(`should return false if fiscal year start value (uint16) is invalid: value: 0x${testCase.toString(16)}`, () => {
+            expect(FiscalYearStart.isValidType(testCase)).toBe(false);
+        });
+    });
+});
+
+// VALIDATE LEAP DAY FEBRUARY 29 IS NOT VALID
+describe('validateFiscalYearStartLeapDay', () => {
+    test(`should return false if fiscal year start value (uint16) for February 29 is invalid: value: 0x0229}`, () => {
+        expect(FiscalYearStart.isValidType(0x0229)).toBe(false);
+    });
+
+    test(`should return error if fiscal year month-day string "02-29" is used to create fiscal year start object`, () => {
+        expect(() => FiscalYearStart.strictFromMonthDashDayString('02-29')).toThrow();
+    });
+
+    test(`should return error if integers "02" and "29" are used to create fiscal year start object`, () => {
+        expect(() => FiscalYearStart.validateMonthDay(2, 29)).toThrow();
+    });
+});
+
+// FISCAL YEAR FROM UNIX TIME
+type TestCase_getFiscalYearFromUnixTime = {
+    date: string;
+    unixTime: number;
+    expected: {
+        [fiscalYearStartId: string]: number;
+    };
+};
+
+let TEST_CASES_GET_FISCAL_YEAR_FROM_UNIX_TIME: TestCase_getFiscalYearFromUnixTime[];
+TEST_CASES_GET_FISCAL_YEAR_FROM_UNIX_TIME = importTestData('test_cases_getFiscalYearFromUnixTime') as TestCase_getFiscalYearFromUnixTime[];
+
+describe('getFiscalYearFromUnixTime', () => {
+    Object.values(TEST_FISCAL_YEAR_START_PRESETS).forEach((testFiscalYearStart) => {
+        TEST_CASES_GET_FISCAL_YEAR_FROM_UNIX_TIME.forEach((testCase) => {
+            test(`returns correct fiscal year for ${getTestTitleFormat(testFiscalYearStart.id, testCase.date)}`, () => {
+                const testCaseUnixTime = moment(testCase.date).unix();
+                const fiscalYear = getFiscalYearFromUnixTime(testCaseUnixTime, testFiscalYearStart.value);
+                const expected = testCase.expected[testFiscalYearStart.id];
+                expect(fiscalYear).toBe(expected);
+            });
+        });
+    });
+});
+
+
+// FISCAL YEAR START UNIX TIME
+type TestCase_getFiscalYearStartUnixTime = {
+    date: string;
+    expected: {
+        [fiscalYearStart: string]: {
+            unixTime: number;
+            unixTimeISO: string;
+        };
+    };
+}
+
+let TEST_CASES_GET_FISCAL_YEAR_START_UNIX_TIME: TestCase_getFiscalYearStartUnixTime[];
+TEST_CASES_GET_FISCAL_YEAR_START_UNIX_TIME = importTestData('test_cases_getFiscalYearStartUnixTime') as TestCase_getFiscalYearStartUnixTime[];
+
+describe('getFiscalYearStartUnixTime', () => {
+    Object.values(TEST_FISCAL_YEAR_START_PRESETS).forEach((testFiscalYearStart) => {
+        TEST_CASES_GET_FISCAL_YEAR_START_UNIX_TIME.forEach((testCase) => {
+            test(`returns correct start unix time for ${getTestTitleFormat(testFiscalYearStart.id, testCase.date)}`, () => {
+                const testCaseUnixTime = moment(testCase.date).unix();
+                const startUnixTime = getFiscalYearStartUnixTime(testCaseUnixTime, testFiscalYearStart.value);
+                const expected = testCase.expected[testFiscalYearStart.id];
+                const unixTimeISO = formatUnixTimeISO(startUnixTime);
+                
+                expect({ unixTime: startUnixTime, ISO: unixTimeISO }).toStrictEqual({ unixTime: expected.unixTime, ISO: expected.unixTimeISO });
+            });
+        });
+    });
+});
+
+
+// FISCAL YEAR END UNIX TIME
+type TestCase_getFiscalYearEndUnixTime = {
+    date: string;
+    expected: {
+        [fiscalYearStart: string]: {
+            unixTime: number;
+            unixTimeISO: string;
+        };
+    };
+}
+
+let TEST_CASES_GET_FISCAL_YEAR_END_UNIX_TIME: TestCase_getFiscalYearEndUnixTime[];
+TEST_CASES_GET_FISCAL_YEAR_END_UNIX_TIME = importTestData('test_cases_getFiscalYearEndUnixTime') as TestCase_getFiscalYearEndUnixTime[];
+
+describe('getFiscalYearEndUnixTime', () => {
+    Object.values(TEST_FISCAL_YEAR_START_PRESETS).forEach((testFiscalYearStart) => {
+        TEST_CASES_GET_FISCAL_YEAR_END_UNIX_TIME.forEach((testCase) => {
+            test(`returns correct end unix time for ${getTestTitleFormat(testFiscalYearStart.id, testCase.date)}`, () => {
+                const testCaseUnixTime = moment(testCase.date).unix();
+                const endUnixTime = getFiscalYearEndUnixTime(testCaseUnixTime, testFiscalYearStart.value);
+                const expected = testCase.expected[testFiscalYearStart.id];
+                const unixTimeISO = formatUnixTimeISO(endUnixTime);
+                
+                expect({ unixTime: endUnixTime, ISO: unixTimeISO }).toStrictEqual({ unixTime: expected.unixTime, ISO: expected.unixTimeISO });
+            
+            });
+        });
+    });
+});
+
+// GET FISCAL YEAR UNIX TIME RANGE
+type TestCase_getFiscalYearUnixTimeRange = {
+    date: string;
+    expected: {
+        [fiscalYearStart: string]: {
+            fiscalYear: number;
+            minUnixTime: number;
+            maxUnixTime: number;
+        }
+    }
+}
+
+let TEST_CASES_GET_FISCAL_YEAR_UNIX_TIME_RANGE: TestCase_getFiscalYearUnixTimeRange[];
+TEST_CASES_GET_FISCAL_YEAR_UNIX_TIME_RANGE = importTestData('test_cases_getFiscalYearUnixTimeRange') as TestCase_getFiscalYearUnixTimeRange[];
+
+describe('getFiscalYearUnixTimeRange', () => {
+    Object.values(TEST_FISCAL_YEAR_START_PRESETS).forEach((testFiscalYearStart) => {
+        TEST_CASES_GET_FISCAL_YEAR_UNIX_TIME_RANGE.forEach((testCase) => {
+            test(`returns correct fiscal year unix time range for ${getTestTitleFormat(testFiscalYearStart.id, testCase.date)}`, () => {
+                const testCaseUnixTime = moment(testCase.date).unix();
+                const fiscalYearUnixTimeRange = getFiscalYearUnixTimeRange(testCaseUnixTime, testFiscalYearStart.value);
+                expect(fiscalYearUnixTimeRange).toStrictEqual(testCase.expected[testFiscalYearStart.id]);
+            });
+        });
+    });
+});

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -203,6 +203,10 @@ export function formatDate(date: string, format: string): string {
     return moment(date, 'YYYY-MM-DD').format(format);
 }
 
+export function formatMonthDay(monthDay: string, format: string): string {
+    return moment(monthDay, 'MM-DD').format(format);
+}
+
 export function getUnixTime(date: SupportedDate): number {
     return moment(date).unix();
 }

--- a/src/lib/fiscalyear.ts
+++ b/src/lib/fiscalyear.ts
@@ -1,0 +1,251 @@
+import moment from 'moment-timezone';
+import { FiscalYearStart } from '@/core/fiscalyear.ts';
+import {
+    getCurrentUnixTime,
+    getUnixTimeBeforeUnixTime,
+    getUnixTimeAfterUnixTime,
+} from '@/lib/datetime.ts';
+
+// Represents a fiscal year with its unix time range
+export interface FiscalYearUnixTime {
+    readonly fiscalYear: number;
+    readonly minUnixTime: number;
+    readonly maxUnixTime: number;
+}
+
+// Get fiscal year for a specific unix time
+export function getFiscalYearFromUnixTime(unixTime: number, fiscalYearStart: number): number {
+    const date = moment.unix(unixTime);
+    
+    // For January 1 fiscal year start, fiscal year matches calendar year
+    if (fiscalYearStart === 0x0101) {
+        return date.year();
+    }
+    
+    // Get date components
+    const month = date.month() + 1; // 1-index
+    const day = date.date();
+    const year = date.year();
+    
+    const [fiscalYearStartMonth, fiscalYearStartDay] = FiscalYearStart.strictFromNumber(fiscalYearStart).values();
+    
+    // For other fiscal year starts:
+    // If input time comes before the fiscal year start day in the calendar year,
+    // it belongs to the fiscal year that ends in the current calendar year
+    if (month < fiscalYearStartMonth || (month === fiscalYearStartMonth && day < fiscalYearStartDay)) {
+        return year;
+    }
+
+    // If input time is on or after the fiscal year start day in the calendar year,
+    // it belongs to the fiscal year that ends in the next calendar year
+    return year + 1;
+}
+
+// Get fiscal year start date for a specific year
+export function getFiscalYearStartUnixTime(unixTime: number, fiscalYearStart: number): number {
+    const date = moment.unix(unixTime);
+    
+    // For January 1 fiscal year start, fiscal year start time is always January 1 in the input calendar year
+    if (fiscalYearStart === 0x0101) {
+        return moment().year(date.year()).month(0).date(1).hour(0).minute(0).second(0).millisecond(0).unix();
+    }
+
+    const [fiscalYearStartMonth, fiscalYearStartDay] = FiscalYearStart.strictFromNumber(fiscalYearStart).values();
+    const month = date.month() + 1; // 1-index
+    const day = date.date();
+    const year = date.year();
+    
+    // For other fiscal year starts:
+    // If input time comes before the fiscal year start day in the calendar year,
+    // the relevant fiscal year has a start date in Calendar Year = Input Year, and end date in Calendar Year = Input Year + 1.
+    // If input time comes on or after the fiscal year start day in the calendar year,
+    // the relevant fiscal year has a start date in Calendar Year = Input Year - 1, and end date in Calendar Year = Input Year.
+    let startYear = year - 1;
+    if (month > fiscalYearStartMonth || (month === fiscalYearStartMonth && day >= fiscalYearStartDay)) {
+        startYear = year;
+    }
+
+    return moment().set({
+        year: startYear,
+        month: fiscalYearStartMonth - 1, // 0-index
+        date: fiscalYearStartDay,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+    }).unix();
+}
+
+// Get fiscal year end date for a specific year
+export function getFiscalYearEndUnixTime(unixTime: number, fiscalYearStart: number): number {
+    const date = moment.unix(unixTime);
+    // For January 1 fiscal year start, fiscal year end time is always December 31 in the input calendar year
+    if (fiscalYearStart === 0x0101) {
+        const result = moment().set({
+            year: date.year(),
+            month: 11, // 0-index
+            date: 31,
+            hour: 23,
+            minute: 59,
+            second: 59,
+            millisecond: 999,
+        });
+        return result.unix();
+    }
+
+    const [fiscalYearStartMonth, fiscalYearStartDay] = FiscalYearStart.strictFromNumber(fiscalYearStart).values();
+    const month = date.month() + 1; // 1-index
+    const day = date.date();
+    const year = date.year();
+    
+    // For other fiscal year starts:
+    // If input time comes before the fiscal year start day in the calendar year,
+    // the relevant fiscal year has a start date in Calendar Year = Input Year, and end date in Calendar Year = Input Year + 1.
+    // If input time comes on or after the fiscal year start day in the calendar year,
+    // the relevant fiscal year has a start date in Calendar Year = Input Year - 1, and end date in Calendar Year = Input Year.
+    let endYear = year;
+    if (month > fiscalYearStartMonth || (month === fiscalYearStartMonth && day >= fiscalYearStartDay)) {
+        endYear = year + 1;
+    }
+
+    return moment().set({
+        year: endYear,
+        month: fiscalYearStartMonth - 1, // 0-index
+        date: fiscalYearStartDay,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+    }).subtract(1, 'second').unix();
+}
+
+// Get current fiscal year
+export function getCurrentFiscalYear(fiscalYearStart: number): number {
+    const date = moment();
+    return getFiscalYearFromUnixTime(date.unix(), fiscalYearStart);
+}
+
+// Get previous fiscal year
+export function getPreviousFiscalYear(fiscalYearStart: number): number {
+    return getFiscalYearFromUnixTime(getCurrentUnixTime(), fiscalYearStart) - 1;
+}
+
+// Get next fiscal year
+export function getNextFiscalYear(fiscalYearStart: number): number {
+    return getFiscalYearFromUnixTime(getCurrentUnixTime(), fiscalYearStart) + 1;
+}
+
+// Is in fiscal year
+export function isInFiscalYear(unixTime: number, fiscalYear: number, fiscalYearStart: number): boolean {
+    return getFiscalYearFromUnixTime(unixTime, fiscalYearStart) === fiscalYear;
+}
+
+// Is start of fiscal year
+export function isStartOfFiscalYear(unixTime: number, fiscalYearStart: number): boolean {
+    return getFiscalYearStartUnixTime(unixTime, fiscalYearStart) === unixTime;
+}
+
+// Is end of fiscal year
+export function isEndOfFiscalYear(unixTime: number, fiscalYearStart: number): boolean {
+    return getFiscalYearEndUnixTime(unixTime, fiscalYearStart) === unixTime;
+}
+
+// Get current fiscal year start unix time
+export function getCurrentFiscalYearStartUnixTime(fiscalYearStart: number): number {
+    const date = moment();
+    return getFiscalYearStartUnixTime(date.unix(), fiscalYearStart);
+}
+
+// Get current fiscal year end unix time
+export function getCurrentFiscalYearEndUnixTime(fiscalYearStart: number): number {
+    const date = moment();
+    return getFiscalYearEndUnixTime(date.unix(), fiscalYearStart);
+}
+
+// Get fiscal year unix time range
+export function getFiscalYearUnixTimeRange(unixTime: number, fiscalYearStart: number): FiscalYearUnixTime {
+    const start = getFiscalYearStartUnixTime(unixTime, fiscalYearStart);
+    const end = getFiscalYearEndUnixTime(unixTime, fiscalYearStart);
+    return {
+        fiscalYear: getFiscalYearFromUnixTime(unixTime, fiscalYearStart),
+        minUnixTime: start,
+        maxUnixTime: end,
+    };
+}
+
+// Get current fiscal year unix time range
+export function getCurrentFiscalYearUnixTimeRange(fiscalYearStart: number): FiscalYearUnixTime {
+    return getFiscalYearUnixTimeRange(getCurrentUnixTime(), fiscalYearStart);
+}
+
+// Get previous fiscal year unix time range
+export function getPreviousFiscalYearUnixTimeRange(unixTime: number, fiscalYearStart: number): FiscalYearUnixTime {
+    const dateInPreviousFiscalYear = getUnixTimeBeforeUnixTime(unixTime, 1, 'year');
+    return getFiscalYearUnixTimeRange(dateInPreviousFiscalYear, fiscalYearStart);
+}
+
+// Get next fiscal year unix time range
+export function getNextFiscalYearUnixTimeRange(unixTime: number, fiscalYearStart: number): FiscalYearUnixTime {
+    const dateInNextFiscalYear = getUnixTimeAfterUnixTime(unixTime, 1, 'year');
+    return getFiscalYearUnixTimeRange(dateInNextFiscalYear, fiscalYearStart);
+}
+
+// Get fiscal years in date range
+export function getFiscalYearsInDateRange(minTime: number, maxTime: number, fiscalYearStartDate: number): number[] {
+    const startFiscalYear = getFiscalYearFromUnixTime(minTime, fiscalYearStartDate);
+    const endFiscalYear = getFiscalYearFromUnixTime(maxTime, fiscalYearStartDate);
+    return Array.from({ length: endFiscalYear - startFiscalYear + 1 }, (_, i) => startFiscalYear + i);
+}
+
+// - getAllYearsStartAndEndUnixTimes
+// - getThisYearFirstUnixTime
+// Get this fiscal year first unix time
+export function getThisFiscalYearFirstUnixTime(fiscalYearStart: number): number {
+    const date = moment();
+    return getFiscalYearStartUnixTime(date.unix(), fiscalYearStart);
+}
+
+// - getThisYearLastUnixTime
+// Get this fiscal year last unix time
+export function getThisFiscalYearLastUnixTime(fiscalYearStart: number): number {
+    const date = moment();
+    return getFiscalYearEndUnixTime(date.unix(), fiscalYearStart);
+}
+
+// - getYearFirstUnixTime
+// Get the first unix time for a specific year
+export function getFiscalYearFirstUnixTime(year: number, fiscalYearStart: number): number {
+    const date = moment().year(year);
+    return getFiscalYearStartUnixTime(date.unix(), fiscalYearStart);
+}
+
+// - getYearLastUnixTime
+// Get the last unix time for a specific year
+export function getFiscalYearLastUnixTime(year: number, fiscalYearStart: number): number {
+    const date = moment().year(year);
+    return getFiscalYearEndUnixTime(date.unix(), fiscalYearStart);
+}
+
+// - getAllYearsStartAndEndUnixTimes
+// Get all fiscal years start and end unix times
+export function getAllFiscalYearsStartAndEndUnixTimes(startYear: number, endYear: number, fiscalYearStart: number): FiscalYearUnixTime[] {
+    const allFiscalYears = [];
+    for (let year = startYear; year <= endYear; year++) {
+        const start = getFiscalYearFirstUnixTime(year, fiscalYearStart);
+        const end = getFiscalYearLastUnixTime(year, fiscalYearStart);
+        allFiscalYears.push({
+            fiscalYear: year,
+            minUnixTime: start,
+            maxUnixTime: end,
+        });
+    }
+    return allFiscalYears;
+}
+
+// - isDateRangeMatchFullFiscalYears
+// Check if a date range spans multiple fiscal years
+export function isDateRangeMatchFullFiscalYears(minTime: number, maxTime: number, fiscalYearStartDate: number): boolean {
+    const startFiscalYear = getFiscalYearFromUnixTime(minTime, fiscalYearStartDate);
+    const endFiscalYear = getFiscalYearFromUnixTime(maxTime, fiscalYearStartDate);
+    return startFiscalYear !== endFiscalYear;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,6 +16,7 @@
     "default": {
         "currency": "USD",
         "firstDayOfWeek": "Sunday",
+        "fiscalYearStart": "01-01",
         "longDateFormat": "MMDDYYYY",
         "shortDateFormat": "MMDDYYYY",
         "longTimeFormat": "HHMMSSA",
@@ -1183,6 +1184,7 @@
         "oldPassword": "Current Password",
         "defaultCurrency": "Default Currency",
         "firstDayOfWeek": "First Day of Week",
+        "FiscalYearStart": "Fiscal Year Start Date",
         "transactionEditScope": "Editable Transaction Range",
         "name": "Name",
         "category": "Category",
@@ -1433,6 +1435,7 @@
     "Default Currency": "Default Currency",
     "Default Account": "Default Account",
     "First Day of Week": "First Day of Week",
+    "Fiscal Year Start Date": "Fiscal Year Start Date",
     "Long Date Format": "Long Date Format",
     "Short Date Format": "Short Date Format",
     "Long Time Format": "Long Time Format",

--- a/src/locales/helpers.ts
+++ b/src/locales/helpers.ts
@@ -47,6 +47,10 @@ import {
 } from '@/core/currency.ts';
 
 import {
+    FiscalYearStart
+} from '@/core/fiscalyear.ts';
+
+import {
     PresetAmountColor
 } from '@/core/color.ts';
 
@@ -601,6 +605,10 @@ export function useI18n() {
 
     function getDefaultFirstDayOfWeek(): string {
         return t('default.firstDayOfWeek');
+    }
+
+    function getDefaultFiscalYearStart(): string {
+        return t('default.fiscalYearStart');
     }
 
     function getAllLanguageOptions(includeSystemDefault: boolean): LanguageOption[] {
@@ -1241,6 +1249,17 @@ export function useI18n() {
         return joinMultiText(finalWeekdayNames);
     }
 
+    function getCurrentFiscalYearStart(): FiscalYearStart {
+        let fiscalYearStart = FiscalYearStart.fromNumber(userStore.currentUserFiscalYearStart);
+        if ( fiscalYearStart ) {
+            return fiscalYearStart;
+        }
+        if ( !fiscalYearStart ) {
+            fiscalYearStart = FiscalYearStart.fromMonthDashDayString(t('default.fiscalYearStart'));
+        }
+        return FiscalYearStart.Default
+    }
+
     function getCurrentDecimalSeparator(): string {
         let decimalSeparatorType = DecimalSeparator.valueOf(userStore.currentUserDecimalSeparator);
 
@@ -1660,6 +1679,7 @@ export function useI18n() {
         // get localization default type
         getDefaultCurrency,
         getDefaultFirstDayOfWeek,
+        getDefaultFiscalYearStart,
         // get all localized info of specified type
         getAllLanguageOptions,
         getAllEnableDisableOptions,
@@ -1710,6 +1730,8 @@ export function useI18n() {
         getWeekdayLongName,
         getMultiMonthdayShortNames,
         getMultiWeekdayLongNames,
+        getLocalizedLongMonthDayFormat,
+        getCurrentFiscalYearStart,
         getCurrentDecimalSeparator,
         getCurrentDigitGroupingSymbol,
         getCurrentDigitGroupingType,

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -4,6 +4,7 @@ import { CurrencyDisplayType } from '@/core/currency.ts';
 import { PresetAmountColor } from '@/core/color.ts';
 import type { LocalizedPresetCategory } from '@/core/category.ts';
 import { TransactionEditScopeType } from '@/core/transaction.ts';
+import { FiscalYearStart } from '@/core/fiscalyear';
 
 export class User {
     public username: string = '';
@@ -17,6 +18,7 @@ export class User {
 
     public defaultAccountId: string = '';
     public transactionEditScope: number = 1;
+    public fiscalYearStart: number = 0;
     public longDateFormat: number = 0;
     public shortDateFormat: number = 0;
     public longTimeFormat: number = 0;
@@ -43,6 +45,7 @@ export class User {
         this.firstDayOfWeek = user.firstDayOfWeek;
         this.defaultAccountId = user.defaultAccountId;
         this.transactionEditScope = user.transactionEditScope;
+        this.fiscalYearStart = user.fiscalYearStart;
         this.longDateFormat = user.longDateFormat;
         this.shortDateFormat = user.shortDateFormat;
         this.longTimeFormat = user.longTimeFormat;
@@ -79,6 +82,7 @@ export class User {
             language: this.language,
             defaultCurrency: this.defaultCurrency,
             firstDayOfWeek: this.firstDayOfWeek,
+            fiscalYearStart: this.fiscalYearStart,
             longDateFormat: this.longDateFormat,
             shortDateFormat: this.shortDateFormat,
             longTimeFormat: this.longTimeFormat,
@@ -96,6 +100,7 @@ export class User {
         const user = new User(userInfo.language, userInfo.defaultCurrency, userInfo.firstDayOfWeek);
         user.defaultAccountId = userInfo.defaultAccountId;
         user.transactionEditScope = userInfo.transactionEditScope;
+        user.fiscalYearStart = userInfo.fiscalYearStart;
         user.longDateFormat = userInfo.longDateFormat;
         user.shortDateFormat = userInfo.shortDateFormat;
         user.longTimeFormat = userInfo.longTimeFormat;
@@ -125,6 +130,7 @@ export interface UserBasicInfo {
     readonly transactionEditScope: number;
     readonly language: string;
     readonly defaultCurrency: string;
+    readonly fiscalYearStart: number;
     readonly firstDayOfWeek: number;
     readonly longDateFormat: number;
     readonly shortDateFormat: number;
@@ -176,6 +182,7 @@ export interface UserProfileUpdateRequest {
     readonly language?: string;
     readonly defaultCurrency?: string;
     readonly firstDayOfWeek?: number;
+    readonly fiscalYearStart?: number;
     readonly longDateFormat?: number;
     readonly shortDateFormat?: number;
     readonly longTimeFormat?: number;
@@ -208,6 +215,7 @@ export const EMPTY_USER_BASIC_INFO: UserBasicInfo = {
     language: '',
     defaultCurrency: '',
     firstDayOfWeek: -1,
+    fiscalYearStart: FiscalYearStart.DefaultNumber,
     longDateFormat: LongDateFormat.Default.type,
     shortDateFormat: ShortDateFormat.Default.type,
     longTimeFormat: LongTimeFormat.Default.type,

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -66,6 +66,11 @@ export const useUserStore = defineStore('user', () => {
         return isNumber(userInfo.firstDayOfWeek) && WeekDay.valueOf(userInfo.firstDayOfWeek) ? userInfo.firstDayOfWeek : settingsStore.localeDefaultSettings.firstDayOfWeek;
     });
 
+    const currentUserFiscalYearStart = computed<number>(() => {
+        const userInfo = currentUserBasicInfo.value || EMPTY_USER_BASIC_INFO;
+        return userInfo.fiscalYearStart;
+    });
+
     const currentUserLongDateFormat = computed<number>(() => {
         const userInfo = currentUserBasicInfo.value || EMPTY_USER_BASIC_INFO;
         return userInfo.longDateFormat;
@@ -316,6 +321,7 @@ export const useUserStore = defineStore('user', () => {
         currentUserLanguage,
         currentUserDefaultCurrency,
         currentUserFirstDayOfWeek,
+        currentUserFiscalYearStart,
         currentUserLongDateFormat,
         currentUserShortDateFormat,
         currentUserLongTimeFormat,

--- a/src/views/base/users/UserProfilePageBase.ts
+++ b/src/views/base/users/UserProfilePageBase.ts
@@ -97,6 +97,7 @@ export function useUserProfilePageBase() {
             newProfile.value.transactionEditScope === oldProfile.value.transactionEditScope &&
             newProfile.value.language === oldProfile.value.language &&
             newProfile.value.defaultCurrency === oldProfile.value.defaultCurrency &&
+            newProfile.value.fiscalYearStart === oldProfile.value.fiscalYearStart &&
             newProfile.value.firstDayOfWeek === oldProfile.value.firstDayOfWeek &&
             newProfile.value.longDateFormat === oldProfile.value.longDateFormat &&
             newProfile.value.shortDateFormat === oldProfile.value.shortDateFormat &&

--- a/src/views/desktop/user/settings/tabs/UserBasicSettingTab.vue
+++ b/src/views/desktop/user/settings/tabs/UserBasicSettingTab.vue
@@ -142,6 +142,18 @@
                                     v-model="newProfile.firstDayOfWeek"
                                 />
                             </v-col>
+
+                            <v-col cols="12" md="6">
+                                <fiscal-year-start-select
+                                    item-title="displayName"
+                                    item-value="type"
+                                    persistent-placeholder
+                                    :disabled="loading || saving"
+                                    :label="tt('Fiscal Year Start Date')"
+                                    :placeholder="tt('Fiscal Year Start Date')"
+                                    v-model="newProfile.fiscalYearStart"
+                                />
+                            </v-col>
                         </v-row>
                     </v-card-text>
 


### PR DESCRIPTION
Feature:
- Add "fiscal year start date" to user profile settings, allowing the user to select any date of the calendar year
- Add "This fiscal year", "Last fiscal year" to 'Custom date range' in Transaction Details, to limit transactions to the period of the user's fiscal year
- Add fiscal year ranges to Statistics & Analysis, to show results pertaining to the period of the user's fiscal year

Done:
- Backend - get/update of fiscal year start date in user profile settings, and basic fiscal year structs
- Frontend - fiscal year lib funcs for unix time - but still need date ranging...
- Frontend - get/update of fiscal year start date in the user Basic Settings UI (desktop), and 

To come:
- Frontend - add fiscal year start date setting to user profile for mobile
- Frontend - add fiscal year range to UI pages that have date ranging - desktop & mobile
- Frontend - add localised fiscal year start default for other language

Implementation notes:
- Fiscal year start date (month number & day number) are stored together as a uint16 - high byte & low byte respectively.
- February 29 is excluded as a fiscal year, since it is never used as a convention in any country
- Jest added as a dev dependency for unit tests in frontend