### PR TITLE
Add support for *_FILE env vars and logging functions to docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,15 +1,82 @@
 #!/bin/sh
 
-set -e;
+set -e
 
-conf_path_param="";
+# Logging functions
+ebk_log() {
+	local type="$1"; shift
+	printf '%s [%s] [Entrypoint]: %s\n' "$(date +"%F %T")" "$type" "$*"
+}
+
+ebk_note() {
+	ebk_log Note "$@"
+}
+
+ebk_warn() {
+	ebk_log Warn "$@" >&2
+}
+
+ebk_error() {
+	ebk_log ERROR "$@" >&2
+	exit 1
+}
+
+#######################################
+# Get values for environment variables from files,
+#   e.g. files from Docker's secrets feature in 
+#   /run/secrets.
+# Usage: 
+#   file_env VAR [DEFAULT]
+#   i.e. file_env 'XYZ_DB_PASSWORD' 'example'
+#   
+#   This will allow to fill in the value of
+#   "$XYZ_DB_PASSWORD" from file path's content
+#   specified in "$XYZ_DB_PASSWORD_FILE")
+#######################################
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+
+	# Equivalent to Bash's variable expansion ${!var} and functional
+	# with all POSIX-compatible shells
+	eval val_var=\$$var
+	eval val_fileVar=\$$fileVar
+
+	if [ -n "$val_var" ] && [ -n "$val_fileVar" ]; then
+		ebk_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+
+	# Set default value if var and fileVar are empty
+	local val="$def"
+
+	if [ -n "$val_var" ]; then
+		val="$val_var"
+	elif [ -n "$val_fileVar" ]; then
+		val="$(cat "$val_fileVar")"
+	fi
+
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# Convert *_FILE's value to corresponding env var
+# To support additional env vars, just add 
+# another line containing
+# file_env 'ENVIRONMENT_VARIABLE'
+file_env 'EBK_SECURITY_SECRET_KEY'
+file_env 'EBK_DATABASE_NAME'
+file_env 'EBK_DATABASE_USER'
+file_env 'EBK_DATABASE_PASSWD'
+
+conf_path_param=""
 
 if [ "${EBK_CONF_PATH}" != "" ]; then
-  conf_path_param="--conf-path=${EBK_CONF_PATH}";
+  conf_path_param="--conf-path=${EBK_CONF_PATH}"
 fi
 
 if [ $# -gt 0 ]; then
     exec "$@"
 else
-    exec /ezbookkeeping/ezbookkeeping server run ${conf_path_param};
+    exec /ezbookkeeping/ezbookkeeping server run ${conf_path_param}
 fi


### PR DESCRIPTION
Some Docker images, such as MariaDB, support to pass values to environment variables from file contents by appending `_FILE` to the corresponding variable. This is useful for passing values from Docker Secrets to these variables in a Docker compose file without having to hardcode them anywhere.
I figured it would be nice for ezbookkeeping's image to support that as well, so you could pass the database password to the container, for example.

Some docs about Docker Swarm's secret engine:
- https://docs.docker.com/engine/swarm/secrets/#about-secrets
- https://docs.docker.com/engine/swarm/secrets/#use-secrets-in-compose

Corresponding function in MariaDB's `docker-entrypoint.sh`, which I rewrote for this project:
- [MariaDB/mariadb-docker/docker-entrypoint.sh](https://github.com/MariaDB/mariadb-docker/blob/fd159432957c53050917081434fea31ea1da451b/docker-entrypoint.sh#L25)

I also added the logging functions for the sake of having them.

As of now, I included the following env vars:

- `EBK_SECURITY_SECRET_KEY`
- `EBK_DATABASE_NAME`
- `EBK_DATABASE_USER`
- `EBK_DATABASE_PASSWD`

Any other env var could be supported by adding `file_env 'ENVIRONMENT_VARIABLE'` to the shell script, if necessary.

Short guide:

1. Init Docker Swarm

- https://docs.docker.com/engine/swarm/swarm-tutorial/

2. Create secrets

For example,
```bash
printf "secret_passwd" | docker secret create ebk_db_pass -
```

3. Include secrets in compose file

Add the secret (`secrets:` block) and any supported environment variable `EBK_ENV_VAR_FILE`, e.g., `EBK_DATABASE_PASSWD_FILE: /run/secrets/<secret_name>`

```yaml
secrets:
  ebk_db_name:
    external: true
  ebk_db_user:
    external: true
  ebk_db_pass:
    external: true
  ebk_db_root_pass:
    external: true
  ebk_secret_key:
    external: true

services:
  server:
    image: "mayswind/ezbookkeeping"
    hostname: "ezbookkeeping"
    ...
    secrets:
      - ebk_db_name
      - ebk_db_user
      - ebk_db_pass
      - ebk_secret_key
    environment:
      EBK_DATABASE_NAME_FILE: /run/secrets/ebk_db_name
      EBK_DATABASE_USER_FILE: /run/secrets/ebk_db_user
      EBK_DATABASE_PASSWD_FILE: /run/secrets/ebk_db_pass
      EBK_SECURITY_SECRET_KEY_FILE: /run/secrets/ebk_secret_key
    depends_on:
      - "database"
    ...

  database:
    image: "mariadb:11.4.2"
    hostname: "mariadb"
    ...
    secrets:
      - ebk_db_name
      - ebk_db_user
      - ebk_db_pass
      - ebk_db_root_pass
    environment:
      MARIADB_DATABASE_FILE: /run/secrets/ebk_db_name
      MARIADB_USER_FILE: /run/secrets/ebk_db_user
      MARIADB_PASSWORD_FILE: /run/secrets/ebk_db_pass
      MARIADB_ROOT_PASSWORD_FILE: /run/secrets/ebk_db_root_pass 
    volumes:
      ...
```

4. ...
5. Profit

Caveat: The secrets will be stored under `/run/secrets/<secret_name>` in plain text inside the container, but that is the way Docker secrets are passed to them. However, this provides more security than hardcoding the secrets into the compose file or storing them in regular files.

Feel free to reach out or to improve or remove code as necessary.

Kind regards!