### PR TITLE
fix: trim trailling spaces in username

### DIFF
--- a/src/views/desktop/LoginPage.vue
+++ b/src/views/desktop/LoginPage.vue
@@ -39,7 +39,7 @@
                                             :disabled="show2faInput || loggingInByPassword || loggingInByOAuth2 || verifying"
                                             :label="tt('Username')"
                                             :placeholder="tt('Your username or email')"
-                                            v-model="username"
+                                            v-model.trim="username"
                                             @input="tempToken = ''"
                                             @keyup.enter="passwordInput?.focus()"
                                         />

--- a/src/views/mobile/LoginPage.vue
+++ b/src/views/mobile/LoginPage.vue
@@ -17,7 +17,7 @@
                 :disabled="loggingInByPassword || loggingInByOAuth2"
                 :label="tt('Username')"
                 :placeholder="tt('Your username or email')"
-                v-model:value="username"
+                v-model:value.trim="username"
                 @input="tempToken = ''"
             ></f7-list-input>
             <f7-list-input


### PR DESCRIPTION
Hi!

Thx for such grate application! I found a some minor issue when try to use PWA application. Android keyboard place a space after completion so I spend several seconds to find out why my username and password isn't correct :)

I think it will be useful to trim all spaces in username.