### PR TITLE
Fix: missing hyphen in 'utf-8' encoding causing error when importing OFX file

### DIFF
--- a/pkg/converters/ofx/ofx_data_reader.go
+++ b/pkg/converters/ofx/ofx_data_reader.go
@@ -23,7 +23,7 @@ import (
 
 const ofx1USAsciiEncoding = "usascii"
 const ofx1UnicodeEncoding = "unicode"
-const ofx1UTF8Encoding = "utf8" // non-standard ofx 1.x encoding, used by some banks (https://github.com/mayswind/ezbookkeeping/issues/48)
+const ofx1UTF8Encoding = "utf-8" // non-standard ofx 1.x encoding, used by some banks (https://github.com/mayswind/ezbookkeeping/issues/48)
 const ofx1SGMLDataFormat = "OFXSGML"
 
 var ofx2HeaderPattern = regexp.MustCompile("<\\?OFX( +[A-Z]+=\"[^=]*\")* *\\?>")


### PR DESCRIPTION
Encountered the same OFX import error as #48. The prior fix added support for 'utf8' encoding, but OFX files require 'utf-8' as stated in the error log. This adds the missing hyphen.