### PR TITLE
fix:params for username field on login page mobile

### DIFF
--- a/src/views/mobile/LoginPage.vue
+++ b/src/views/mobile/LoginPage.vue
@@ -13,6 +13,10 @@
             <f7-list-input
                 type="text"
                 autocomplete="username"
+                autocapitalize="none"
+                autocorrect="off"
+                spellcheck="false"
+                inputmode="email"
                 clear-button
                 :disabled="loggingInByPassword || loggingInByOAuth2"
                 :label="tt('Username')"


### PR DESCRIPTION
I kept getting autocapitalization, suggestions and autocorrect for my username on mobile. i don't believe it should be doing any of that on a login field.
I also made the input mode to email for convenience.