### PR TITLE
fix final rate calculation for the National Bank of Kazakhstan

### DIFF
--- a/pkg/exchangerates/national_bank_of_kazakhstan_datasource.go
+++ b/pkg/exchangerates/national_bank_of_kazakhstan_datasource.go
@@ -116,7 +116,7 @@ func (e *NationalBankOfKazakhstanExchangeRate) ToLatestExchangeRate(c core.Conte
 		return nil
 	}
 
-	finalRate := rate / unit
+	finalRate := unit / rate
 	if math.IsInf(finalRate, 0) {
 		log.Warnf(c, "[national_bank_of_kazakhstan_datasource.ToLatestExchangeRate] final exchange rate calculation failed, currency is %s, unit is %s, rate is %s", e.Currency, e.Unit, e.Rate)
 		return nil

--- a/pkg/exchangerates/national_bank_of_kazakhstan_datasource_test.go
+++ b/pkg/exchangerates/national_bank_of_kazakhstan_datasource_test.go
@@ -55,12 +55,12 @@ func TestNationalBankOfKazakhstanDataSource_StandardDataExtractExchangeRates(t *
 
 	assert.Contains(t, resp.ExchangeRates, &models.LatestExchangeRate{
 		Currency: "USD",
-		Rate:     "450.5",
+		Rate:     "0.0022197558268590455",
 	})
 
 	assert.Contains(t, resp.ExchangeRates, &models.LatestExchangeRate{
 		Currency: "VND",
-		Rate:     "0.0018",
+		Rate:     "555.5555555555555",
 	})
 }
 


### PR DESCRIPTION
Apologies - I realized the rate calculation in the #564  was incorrect (`rate / unit` instead of `unit / rate`). This PR fixes that issue.