### PR TITLE
fix(mcp): handle TRANSACTION_DB_TYPE_TRANSFER_IN in query_transactions response

### DIFF
--- a/pkg/mcp/query_transactions_tool_handler.go
+++ b/pkg/mcp/query_transactions_tool_handler.go
@@ -198,7 +198,7 @@ func (h *mcpQueryTransactionsToolHandler) createNewMCPQueryTransactionsResponse(
 			transactionInfo.Type = transactionTypeExpense
 		} else if transaction.Type == models.TRANSACTION_DB_TYPE_INCOME {
 			transactionInfo.Type = transactionTypeIncome
-		} else if transaction.Type == models.TRANSACTION_DB_TYPE_TRANSFER_OUT {
+		} else if transaction.Type == models.TRANSACTION_DB_TYPE_TRANSFER_OUT || transaction.Type == models.TRANSACTION_DB_TYPE_TRANSFER_IN {
 			transactionInfo.Type = transactionTypeTransfer
 		}
 


### PR DESCRIPTION
## Description

The MCP `query_transactions` response builder only maps `TRANSACTION_DB_TYPE_TRANSFER_OUT` (type 4) to `"transfer"`, leaving `TRANSACTION_DB_TYPE_TRANSFER_IN` (type 5) as an empty string `""`.

When the database contains paired transfer transactions (which use types 4 and 5), the MCP tool returns `"type": ""` for the transfer-in row, which fails the JSON schema enum validation `['income', 'expense', 'transfer']`.

## Root Cause

In `createNewMCPQueryTransactionsResponse` (`query_transactions_tool_handler.go:197-203`), the type mapping handles:
- `TRANSACTION_DB_TYPE_EXPENSE (3)` → `"expense"` ✓
- `TRANSACTION_DB_TYPE_INCOME (2)` → `"income"` ✓
- `TRANSACTION_DB_TYPE_TRANSFER_OUT (4)` → `"transfer"` ✓
- `TRANSACTION_DB_TYPE_TRANSFER_IN (5)` → `""` ✗ (missing)

## Fix

Add `TRANSACTION_DB_TYPE_TRANSFER_IN` to the same condition as `TRANSACTION_DB_TYPE_TRANSFER_OUT`, since both represent transfer transactions in the MCP response model.

Fixes #586
