### PR TITLE
Improve ezBookkeeping skill API coverage and tooling

### DIFF
--- a/skills/ezbookkeeping/SKILL.md
+++ b/skills/ezbookkeeping/SKILL.md
@@ -1,65 +1,112 @@
 ---
 name: ezbookkeeping
-description: Use ezBookkeeping API Tools script to record new transactions, query transactions, retrieve account information, retrieve categories, retrieve tags, and retrieve exchange rate data in the self hosted personal finance application ezBookkeeping.
+description: Use ezBookkeeping API Tools to query and manage a self-hosted ezBookkeeping instance, including accounts, transaction categories, tag groups, tags, transactions, exchange rates, sessions, and server version. Use when an agent needs to list, inspect, create, modify, move, hide, delete, or batch-update personal finance records through ezBookkeeping API commands.
 ---
 
 # ezBookkeeping API Tools
 
-## Usage
+Use the bundled scripts in `scripts/` to call ezBookkeeping `/api/v1` endpoints. Prefer the script over hand-written HTTP calls because it handles authentication, timezone headers, parameter typing, formatted output, and dry-run previews.
 
-### List all supported commands
+## Setup
 
-Linux / macOS
+Set credentials in environment variables, or in a `.env` file in the current directory, parent directory, or home directory:
 
-```bash
-sh scripts/ebktools.sh list
+```text
+EBKTOOL_SERVER_BASEURL=http://localhost:8080
+EBKTOOL_TOKEN=YOUR_TOKEN
 ```
 
-Windows
+The scripts load command definitions from `scripts/api-configs.json`. To discover current coverage and exact parameters, run:
 
 ```powershell
 scripts\ebktools.ps1 list
+scripts\ebktools.ps1 help transactions-add
 ```
-
-### Show help for a specific command
-
-Linux / macOS
 
 ```bash
-sh scripts/ebktools.sh help <command>
+sh scripts/ebktools.sh list
+sh scripts/ebktools.sh help transactions-add
 ```
 
-Windows
+## Command Use
 
-```powershell
-scripts\ebktools.ps1 help <command>
-```
-
-### Call API
-
-Linux / macOS
-
-```bash
-sh scripts/ebktools.sh [global-options] <command> [command-options]
-```
-
-Windows
+Use PowerShell on Windows:
 
 ```powershell
 scripts\ebktools.ps1 [global-options] <command> [command-options]
 ```
 
-## Troubleshooting
+Use POSIX shell on Linux/macOS:
 
-If the script reports that the environment variable `EBKTOOL_SERVER_BASEURL` or `EBKTOOL_TOKEN` is not set, user can define them as system environment variables, or create a `.env` file in the user home directory that contains these two variables and place it there.
+```bash
+sh scripts/ebktools.sh [global-options] <command> [command-options]
+```
 
-The meanings of these environment variables are as follows:
+Global options:
 
-| Variable | Required | Description |
+| PowerShell | Shell | Purpose |
 | --- | --- | --- |
-| `EBKTOOL_SERVER_BASEURL` | Required | ezBookkeeping server base URL (e.g., `http://localhost:8080`) |
-| `EBKTOOL_TOKEN` | Required | ezBookkeeping API token |
+| `-tzName <name>` | `--tz-name <name>` | Send an IANA timezone name, such as `Asia/Shanghai`. |
+| `-tzOffset <minutes>` | `--tz-offset <minutes>` | Send timezone offset minutes, such as `480`. |
+| `-rawResponse` | `--raw-response` | Print raw JSON instead of tables. |
+| `-dryRun` | `--dry-run` | Print method, URL, headers, and body without sending the request. |
 
-## Reference
+Use dry-run before destructive or broad write operations, then ask the user to confirm before executing the real command. This especially applies to `tokens-revoke`, `accounts-delete`, `accounts-sub-account-delete`, category/tag/tag-group deletes, `transactions-delete`, `transactions-batch-delete`, `transactions-move-all`, transaction batch updates, and `exchangerates-custom-delete`.
 
-ezBookkeeping: [https://ezbookkeeping.mayswind.net](https://ezbookkeeping.mayswind.net)
+## Parameter Rules
+
+Pass amounts as integer minor units: `1234` means `12.34`; expenses or liabilities may require negative values, such as `-1234`.
+
+Pass comma-separated IDs for `string_array` parameters such as `tagIds`, `pictureIds`, `transactionIds`, and `ids`:
+
+```powershell
+scripts\ebktools.ps1 -dryRun transactions-batch-add-tags -transactionIds 1001,1002 -tagIds 8,9
+```
+
+Pass `geo_location` as `longitude,latitude`:
+
+```powershell
+scripts\ebktools.ps1 -dryRun transactions-add -type 3 -categoryId 12 -time 1710000000 -utcOffset 480 -sourceAccountId 1 -sourceAmount -1234 -geoLocation 116.33,39.93
+```
+
+Pass object or array parameters as JSON strings for commands such as `accounts-move`, `transaction-categories-add-batch`, `transaction-tags-add-batch`, and tag/category/account move commands:
+
+```powershell
+scripts\ebktools.ps1 -dryRun accounts-move -newDisplayOrders '[{"id":"1","displayOrder":1}]'
+```
+
+```bash
+sh scripts/ebktools.sh --dry-run accounts-move --newDisplayOrders '[{"id":"1","displayOrder":1}]'
+```
+
+## Common Workflows
+
+Inspect current bookkeeping data before writing:
+
+```powershell
+scripts\ebktools.ps1 accounts-list
+scripts\ebktools.ps1 transaction-categories-list
+scripts\ebktools.ps1 transaction-tags-list
+scripts\ebktools.ps1 transactions-list -count 20
+```
+
+Create or modify a transaction:
+
+```powershell
+scripts\ebktools.ps1 -dryRun transactions-add -type 3 -categoryId 12 -time 1710000000 -utcOffset 480 -sourceAccountId 1 -sourceAmount -1234 -tagIds 8,9 -comment "Lunch"
+scripts\ebktools.ps1 help transactions-modify
+```
+
+Update supporting metadata:
+
+```powershell
+scripts\ebktools.ps1 -dryRun transaction-tags-add -name "Business" -groupId 0
+scripts\ebktools.ps1 -dryRun transaction-categories-hide -id 12 -hidden true
+```
+
+Manage exchange rates:
+
+```powershell
+scripts\ebktools.ps1 exchangerates-latest
+scripts\ebktools.ps1 -dryRun exchangerates-custom-update -currency USD -rate 7.2
+```

--- a/skills/ezbookkeeping/scripts/api-configs.json
+++ b/skills/ezbookkeeping/scripts/api-configs.json
@@ -1,0 +1,1403 @@
+[
+  {
+    "Name": "tokens-list",
+    "Description": "Retrieve all sessions for the current user",
+    "Method": "GET",
+    "Path": "tokens/list.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [],
+    "ParamTypes": {},
+    "ParamDescriptions": {},
+    "PrettyResponse": {
+      "Type": "simple_array_to_markdown_table",
+      "Columns": [
+        "tokenId",
+        "tokenType",
+        "userAgent",
+        "lastSeen",
+        "isCurrent"
+      ]
+    }
+  },
+  {
+    "Name": "tokens-revoke",
+    "Description": "Revoke a specified token",
+    "Method": "POST",
+    "Path": "tokens/revoke.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "tokenId"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "tokenId": "string"
+    },
+    "ParamDescriptions": {
+      "tokenId": "string (Token ID)"
+    }
+  },
+  {
+    "Name": "accounts-list",
+    "Description": "Retrieve account information",
+    "Method": "GET",
+    "Path": "accounts/list.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [
+      "visible_only"
+    ],
+    "ParamTypes": {
+      "visible_only": "boolean"
+    },
+    "ParamDescriptions": {
+      "visible_only": "boolean (Whether to return visible accounts only)"
+    },
+    "PrettyResponse": {
+      "Type": "hierarchical_array_to_markdown_table",
+      "Columns": [
+        "category",
+        "type",
+        "parentId",
+        "id",
+        "name",
+        "currency",
+        "balance",
+        "hidden",
+        "comment"
+      ],
+      "ChildKey": "subAccounts"
+    }
+  },
+  {
+    "Name": "accounts-get",
+    "Description": "Retrieve one account by ID",
+    "Method": "GET",
+    "Path": "accounts/get.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)"
+    }
+  },
+  {
+    "Name": "accounts-add",
+    "Description": "Add a new account",
+    "Method": "POST",
+    "Path": "accounts/add.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "name",
+      "category",
+      "type",
+      "icon",
+      "color",
+      "currency"
+    ],
+    "OptionalParams": [
+      "balance",
+      "balanceTime",
+      "comment",
+      "creditCardStatementDate",
+      "subAccounts",
+      "clientSessionId"
+    ],
+    "ParamTypes": {
+      "name": "string",
+      "icon": "string",
+      "color": "string",
+      "currency": "string",
+      "comment": "string",
+      "clientSessionId": "string",
+      "category": "integer",
+      "type": "integer",
+      "balance": "integer",
+      "balanceTime": "integer",
+      "creditCardStatementDate": "integer",
+      "subAccounts": "json"
+    },
+    "ParamDescriptions": {
+      "name": "string (Account name)",
+      "category": "integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)",
+      "type": "integer (Account type, 1: Single Account, 2: Multiple Sub-accounts)",
+      "icon": "string (Account icon ID)",
+      "color": "string (Account icon color, hex color code RRGGBB)",
+      "currency": "string (Account currency code, ISO 4217 code; --- for parent account)",
+      "balance": "integer (Account balance, scaled by 100; liability account should use negative amount)",
+      "balanceTime": "integer (Unix time when the opening balance applies)",
+      "comment": "string (Account description)",
+      "creditCardStatementDate": "integer (Statement date for credit card account, 0-28)",
+      "subAccounts": "json (Sub-account create/modify requests)",
+      "clientSessionId": "string (Client session ID for duplicate submission protection)"
+    }
+  },
+  {
+    "Name": "accounts-modify",
+    "Description": "Modify an existing account",
+    "Method": "POST",
+    "Path": "accounts/modify.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "id",
+      "name",
+      "category",
+      "icon",
+      "color",
+      "hidden"
+    ],
+    "OptionalParams": [
+      "currency",
+      "balance",
+      "balanceTime",
+      "lastReconciledTime",
+      "comment",
+      "creditCardStatementDate",
+      "subAccounts",
+      "clientSessionId"
+    ],
+    "ParamTypes": {
+      "id": "string",
+      "name": "string",
+      "icon": "string",
+      "color": "string",
+      "currency": "string",
+      "comment": "string",
+      "clientSessionId": "string",
+      "category": "integer",
+      "balance": "integer",
+      "balanceTime": "integer",
+      "lastReconciledTime": "integer",
+      "creditCardStatementDate": "integer",
+      "hidden": "boolean",
+      "subAccounts": "json"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)",
+      "name": "string (Account name)",
+      "category": "integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)",
+      "icon": "string (Account icon ID)",
+      "color": "string (Account icon color, hex color code RRGGBB)",
+      "currency": "string (Account currency code, ISO 4217 code; --- for parent account)",
+      "balance": "integer (Account balance, scaled by 100; liability account should use negative amount)",
+      "balanceTime": "integer (Unix time when the opening balance applies)",
+      "lastReconciledTime": "integer (Last reconciled unix time)",
+      "comment": "string (Account description)",
+      "creditCardStatementDate": "integer (Statement date for credit card account, 0-28)",
+      "hidden": "boolean (Whether the account is hidden)",
+      "subAccounts": "json (Sub-account create/modify requests)",
+      "clientSessionId": "string (Client session ID for duplicate submission protection)"
+    }
+  },
+  {
+    "Name": "accounts-update-last-reconciled-time",
+    "Description": "Update last reconciled time for an account",
+    "Method": "POST",
+    "Path": "accounts/update/last_reconciled_time.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "lastReconciledTime"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string",
+      "lastReconciledTime": "integer"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)",
+      "lastReconciledTime": "integer (Last reconciled unix time)"
+    }
+  },
+  {
+    "Name": "accounts-hide",
+    "Description": "Hide or unhide an account",
+    "Method": "POST",
+    "Path": "accounts/hide.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "hidden"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string",
+      "hidden": "boolean"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)",
+      "hidden": "boolean (Whether the account is hidden)"
+    }
+  },
+  {
+    "Name": "accounts-move",
+    "Description": "Update account display order",
+    "Method": "POST",
+    "Path": "accounts/move.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "newDisplayOrders"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "newDisplayOrders": "json"
+    },
+    "ParamDescriptions": {
+      "newDisplayOrders": "json (Array of objects: [{\"id\":\"123\",\"displayOrder\":1}])"
+    }
+  },
+  {
+    "Name": "accounts-delete",
+    "Description": "Delete an account",
+    "Method": "POST",
+    "Path": "accounts/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)"
+    }
+  },
+  {
+    "Name": "accounts-sub-account-delete",
+    "Description": "Delete a sub-account",
+    "Method": "POST",
+    "Path": "accounts/sub_account/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Account ID)"
+    }
+  },
+  {
+    "Name": "transaction-categories-list",
+    "Description": "Retrieve transaction categories",
+    "Method": "GET",
+    "Path": "transaction/categories/list.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [
+      "type",
+      "parent_id"
+    ],
+    "ParamTypes": {
+      "type": "integer",
+      "parent_id": "string"
+    },
+    "ParamDescriptions": {
+      "type": "integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)",
+      "parent_id": "string (Filter by parent transaction category ID; -1 means all)"
+    },
+    "PrettyResponse": {
+      "Type": "hierarchical_object_to_markdown_table",
+      "Columns": [
+        "type",
+        "parentId",
+        "id",
+        "name",
+        "hidden",
+        "comment"
+      ],
+      "ChildKey": "subCategories"
+    }
+  },
+  {
+    "Name": "transaction-categories-get",
+    "Description": "Retrieve one transaction category by ID",
+    "Method": "GET",
+    "Path": "transaction/categories/get.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction category ID)"
+    }
+  },
+  {
+    "Name": "transaction-categories-add",
+    "Description": "Add a new transaction category",
+    "Method": "POST",
+    "Path": "transaction/categories/add.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "name",
+      "type",
+      "icon",
+      "color"
+    ],
+    "OptionalParams": [
+      "parentId",
+      "comment",
+      "clientSessionId"
+    ],
+    "ParamTypes": {
+      "name": "string",
+      "icon": "string",
+      "color": "string",
+      "parentId": "string",
+      "comment": "string",
+      "clientSessionId": "string",
+      "type": "integer"
+    },
+    "ParamDescriptions": {
+      "name": "string (Transaction category name)",
+      "type": "integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)",
+      "parentId": "string (Parent transaction category ID, 0 for primary category)",
+      "icon": "string (Transaction category icon ID)",
+      "color": "string (Transaction category color, hex color code RRGGBB)",
+      "comment": "string (Transaction category description)",
+      "clientSessionId": "string (Client session ID for duplicate submission protection)"
+    }
+  },
+  {
+    "Name": "transaction-categories-add-batch",
+    "Description": "Add multiple transaction categories",
+    "Method": "POST",
+    "Path": "transaction/categories/add_batch.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "categories"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "categories": "json"
+    },
+    "ParamDescriptions": {
+      "categories": "json (Batch category tree, see help and API model for shape)"
+    }
+  },
+  {
+    "Name": "transaction-categories-modify",
+    "Description": "Modify a transaction category",
+    "Method": "POST",
+    "Path": "transaction/categories/modify.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "name",
+      "parentId",
+      "icon",
+      "color",
+      "hidden"
+    ],
+    "OptionalParams": [
+      "comment"
+    ],
+    "ParamTypes": {
+      "id": "string",
+      "name": "string",
+      "parentId": "string",
+      "icon": "string",
+      "color": "string",
+      "comment": "string",
+      "hidden": "boolean"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction category ID)",
+      "name": "string (Transaction category name)",
+      "parentId": "string (Parent transaction category ID, 0 for primary category)",
+      "icon": "string (Transaction category icon ID)",
+      "color": "string (Transaction category color, hex color code RRGGBB)",
+      "comment": "string (Transaction category description)",
+      "hidden": "boolean (Whether the category is hidden)"
+    }
+  },
+  {
+    "Name": "transaction-categories-hide",
+    "Description": "Hide or unhide a transaction category",
+    "Method": "POST",
+    "Path": "transaction/categories/hide.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "hidden"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string",
+      "hidden": "boolean"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction category ID)",
+      "hidden": "boolean (Whether the category is hidden)"
+    }
+  },
+  {
+    "Name": "transaction-categories-move",
+    "Description": "Update transaction category display order",
+    "Method": "POST",
+    "Path": "transaction/categories/move.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "newDisplayOrders"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "newDisplayOrders": "json"
+    },
+    "ParamDescriptions": {
+      "newDisplayOrders": "json (Array of objects: [{\"id\":\"123\",\"displayOrder\":1}])"
+    }
+  },
+  {
+    "Name": "transaction-categories-delete",
+    "Description": "Delete a transaction category",
+    "Method": "POST",
+    "Path": "transaction/categories/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction category ID)"
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-list",
+    "Description": "Retrieve transaction tag groups",
+    "Method": "GET",
+    "Path": "transaction/tags/groups/list.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [],
+    "ParamTypes": {},
+    "ParamDescriptions": {},
+    "PrettyResponse": {
+      "Type": "simple_array_to_markdown_table",
+      "Columns": [
+        "id",
+        "name",
+        "displayOrder"
+      ]
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-get",
+    "Description": "Retrieve one transaction tag group by ID",
+    "Method": "GET",
+    "Path": "transaction/tags/groups/get.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag group ID)"
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-add",
+    "Description": "Add a transaction tag group",
+    "Method": "POST",
+    "Path": "transaction/tags/groups/add.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "name"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "name": "string"
+    },
+    "ParamDescriptions": {
+      "name": "string (Transaction tag group name)"
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-modify",
+    "Description": "Modify a transaction tag group",
+    "Method": "POST",
+    "Path": "transaction/tags/groups/modify.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "name"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string",
+      "name": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag group ID)",
+      "name": "string (Transaction tag group name)"
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-move",
+    "Description": "Update transaction tag group display order",
+    "Method": "POST",
+    "Path": "transaction/tags/groups/move.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "newDisplayOrders"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "newDisplayOrders": "json"
+    },
+    "ParamDescriptions": {
+      "newDisplayOrders": "json (Array of objects: [{\"id\":\"123\",\"displayOrder\":1}])"
+    }
+  },
+  {
+    "Name": "transaction-tag-groups-delete",
+    "Description": "Delete a transaction tag group",
+    "Method": "POST",
+    "Path": "transaction/tags/groups/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag group ID)"
+    }
+  },
+  {
+    "Name": "transaction-tags-list",
+    "Description": "Retrieve transaction tags",
+    "Method": "GET",
+    "Path": "transaction/tags/list.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [],
+    "ParamTypes": {},
+    "ParamDescriptions": {},
+    "PrettyResponse": {
+      "Type": "simple_array_to_markdown_table",
+      "Columns": [
+        "groupId",
+        "id",
+        "name",
+        "hidden"
+      ]
+    }
+  },
+  {
+    "Name": "transaction-tags-get",
+    "Description": "Retrieve one transaction tag by ID",
+    "Method": "GET",
+    "Path": "transaction/tags/get.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag ID)"
+    }
+  },
+  {
+    "Name": "transaction-tags-add",
+    "Description": "Add a new transaction tag",
+    "Method": "POST",
+    "Path": "transaction/tags/add.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "name"
+    ],
+    "OptionalParams": [
+      "groupId"
+    ],
+    "ParamTypes": {
+      "name": "string",
+      "groupId": "string"
+    },
+    "ParamDescriptions": {
+      "name": "string (Transaction tag name)",
+      "groupId": "string (Transaction tag group ID, 0 means default group)"
+    }
+  },
+  {
+    "Name": "transaction-tags-add-batch",
+    "Description": "Add multiple transaction tags",
+    "Method": "POST",
+    "Path": "transaction/tags/add_batch.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "tags",
+      "groupId"
+    ],
+    "OptionalParams": [
+      "skipExists"
+    ],
+    "ParamTypes": {
+      "tags": "json",
+      "groupId": "string",
+      "skipExists": "boolean"
+    },
+    "ParamDescriptions": {
+      "tags": "json (Array of tag create requests: [{\"name\":\"name\",\"groupId\":\"0\"}])",
+      "groupId": "string (Transaction tag group ID, 0 means default group)",
+      "skipExists": "boolean (Whether to ignore existing tags in batch creation)"
+    }
+  },
+  {
+    "Name": "transaction-tags-modify",
+    "Description": "Modify a transaction tag",
+    "Method": "POST",
+    "Path": "transaction/tags/modify.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "name"
+    ],
+    "OptionalParams": [
+      "groupId"
+    ],
+    "ParamTypes": {
+      "id": "string",
+      "name": "string",
+      "groupId": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag ID)",
+      "name": "string (Transaction tag name)",
+      "groupId": "string (Transaction tag group ID, 0 means default group)"
+    }
+  },
+  {
+    "Name": "transaction-tags-hide",
+    "Description": "Hide or unhide a transaction tag",
+    "Method": "POST",
+    "Path": "transaction/tags/hide.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id",
+      "hidden"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string",
+      "hidden": "boolean"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag ID)",
+      "hidden": "boolean (Whether the tag is hidden)"
+    }
+  },
+  {
+    "Name": "transaction-tags-move",
+    "Description": "Update transaction tag display order",
+    "Method": "POST",
+    "Path": "transaction/tags/move.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "newDisplayOrders"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "newDisplayOrders": "json"
+    },
+    "ParamDescriptions": {
+      "newDisplayOrders": "json (Array of objects: [{\"id\":\"123\",\"displayOrder\":1}])"
+    }
+  },
+  {
+    "Name": "transaction-tags-delete",
+    "Description": "Delete a transaction tag",
+    "Method": "POST",
+    "Path": "transaction/tags/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction tag ID)"
+    }
+  },
+  {
+    "Name": "transactions-count",
+    "Description": "Count transactions matching query criteria",
+    "Method": "GET",
+    "Path": "transactions/count.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [
+      "type",
+      "category_ids",
+      "account_ids",
+      "tag_filter",
+      "amount_filter",
+      "keyword",
+      "must_have_pictures",
+      "max_time",
+      "min_time"
+    ],
+    "ParamTypes": {
+      "type": "integer",
+      "max_time": "integer",
+      "min_time": "integer",
+      "category_ids": "string",
+      "account_ids": "string",
+      "tag_filter": "string",
+      "amount_filter": "string",
+      "keyword": "string",
+      "must_have_pictures": "boolean"
+    },
+    "ParamDescriptions": {
+      "type": "integer (Filter by transaction type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
+      "category_ids": "string (Filter by category IDs, separated by comma)",
+      "account_ids": "string (Filter by account IDs, separated by comma)",
+      "tag_filter": "string (Filter by tags, e.g. type:tagid,tagid; another filter)",
+      "amount_filter": "string (Filter by amount)",
+      "keyword": "string (Filter by keyword)",
+      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
+      "max_time": "integer (Maximum transaction time sequence ID)",
+      "min_time": "integer (Minimum transaction time sequence ID)"
+    }
+  },
+  {
+    "Name": "transactions-list",
+    "Description": "Retrieve transaction data based on query criteria with pagination",
+    "Method": "GET",
+    "Path": "transactions/list.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "count"
+    ],
+    "OptionalParams": [
+      "type",
+      "category_ids",
+      "account_ids",
+      "tag_filter",
+      "amount_filter",
+      "keyword",
+      "must_have_pictures",
+      "max_time",
+      "min_time",
+      "page",
+      "with_count",
+      "with_pictures",
+      "trim_account",
+      "trim_category",
+      "trim_tag"
+    ],
+    "ParamTypes": {
+      "count": "integer",
+      "type": "integer",
+      "max_time": "integer",
+      "min_time": "integer",
+      "page": "integer",
+      "category_ids": "string",
+      "account_ids": "string",
+      "tag_filter": "string",
+      "amount_filter": "string",
+      "keyword": "string",
+      "must_have_pictures": "boolean",
+      "with_count": "boolean",
+      "with_pictures": "boolean",
+      "trim_account": "boolean",
+      "trim_category": "boolean",
+      "trim_tag": "boolean"
+    },
+    "ParamDescriptions": {
+      "count": "integer (Transactions per page, maximum is 50)",
+      "type": "integer (Filter by transaction type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
+      "category_ids": "string (Filter by category IDs, separated by comma)",
+      "account_ids": "string (Filter by account IDs, separated by comma)",
+      "tag_filter": "string (Filter by tags, e.g. type:tagid,tagid; another filter)",
+      "amount_filter": "string (Filter by amount)",
+      "keyword": "string (Filter by keyword)",
+      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
+      "max_time": "integer (Maximum time sequence ID; 0 for latest)",
+      "min_time": "integer (Minimum time sequence ID)",
+      "page": "integer (Page number)",
+      "with_count": "boolean (Whether to include total count)",
+      "with_pictures": "boolean (Whether to include transaction picture IDs)",
+      "trim_account": "boolean (Whether to return account IDs only)",
+      "trim_category": "boolean (Whether to return category IDs only)",
+      "trim_tag": "boolean (Whether to return tag IDs only)"
+    },
+    "PrettyResponse": {
+      "Type": "nested_array_to_markdown_table",
+      "Columns": [
+        "id",
+        "type",
+        "time",
+        "utcOffset",
+        "categoryId",
+        "sourceAccountId",
+        "sourceAmount",
+        "destinationAccountId",
+        "destinationAmount",
+        "tagIds",
+        "geoLocation",
+        "comment"
+      ],
+      "DataPath": "items",
+      "Metadata": [
+        {
+          "Field": "totalCount",
+          "Label": "Total Count"
+        },
+        {
+          "Field": "nextTimeSequenceId",
+          "Label": "Next Time Sequence ID"
+        }
+      ]
+    }
+  },
+  {
+    "Name": "transactions-list-by-month",
+    "Description": "Retrieve transactions in a specified month",
+    "Method": "GET",
+    "Path": "transactions/list/by_month.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "year",
+      "month"
+    ],
+    "OptionalParams": [
+      "type",
+      "category_ids",
+      "account_ids",
+      "tag_filter",
+      "amount_filter",
+      "keyword",
+      "must_have_pictures",
+      "with_pictures",
+      "trim_account",
+      "trim_category",
+      "trim_tag"
+    ],
+    "ParamTypes": {
+      "year": "integer",
+      "month": "integer",
+      "type": "integer",
+      "category_ids": "string",
+      "account_ids": "string",
+      "tag_filter": "string",
+      "amount_filter": "string",
+      "keyword": "string",
+      "must_have_pictures": "boolean",
+      "with_pictures": "boolean",
+      "trim_account": "boolean",
+      "trim_category": "boolean",
+      "trim_tag": "boolean"
+    },
+    "ParamDescriptions": {
+      "year": "integer (Gregorian year)",
+      "month": "integer (1-based month)",
+      "type": "integer (Filter by transaction type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
+      "category_ids": "string (Filter by category IDs, separated by comma)",
+      "account_ids": "string (Filter by account IDs, separated by comma)",
+      "tag_filter": "string (Filter by tags, e.g. type:tagid,tagid; another filter)",
+      "amount_filter": "string (Filter by amount)",
+      "keyword": "string (Filter by keyword)",
+      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
+      "with_pictures": "boolean (Whether to include transaction picture IDs)",
+      "trim_account": "boolean (Whether to return account IDs only)",
+      "trim_category": "boolean (Whether to return category IDs only)",
+      "trim_tag": "boolean (Whether to return tag IDs only)"
+    },
+    "PrettyResponse": {
+      "Type": "nested_array_to_markdown_table",
+      "Columns": [
+        "id",
+        "type",
+        "time",
+        "utcOffset",
+        "categoryId",
+        "sourceAccountId",
+        "sourceAmount",
+        "destinationAccountId",
+        "destinationAmount",
+        "tagIds",
+        "geoLocation",
+        "comment"
+      ],
+      "DataPath": "items",
+      "Metadata": [
+        {
+          "Field": "totalCount",
+          "Label": "Total Count"
+        },
+        {
+          "Field": "nextTimeSequenceId",
+          "Label": "Next Time Sequence ID"
+        }
+      ]
+    }
+  },
+  {
+    "Name": "transactions-list-all",
+    "Description": "Retrieve all transaction data matching query criteria",
+    "Method": "GET",
+    "Path": "transactions/list/all.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [],
+    "OptionalParams": [
+      "type",
+      "category_ids",
+      "account_ids",
+      "tag_filter",
+      "amount_filter",
+      "keyword",
+      "must_have_pictures",
+      "start_time",
+      "end_time",
+      "with_pictures",
+      "trim_account",
+      "trim_category",
+      "trim_tag"
+    ],
+    "ParamTypes": {
+      "type": "integer",
+      "start_time": "integer",
+      "end_time": "integer",
+      "category_ids": "string",
+      "account_ids": "string",
+      "tag_filter": "string",
+      "amount_filter": "string",
+      "keyword": "string",
+      "must_have_pictures": "boolean",
+      "with_pictures": "boolean",
+      "trim_account": "boolean",
+      "trim_category": "boolean",
+      "trim_tag": "boolean"
+    },
+    "ParamDescriptions": {
+      "type": "integer (Filter by transaction type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
+      "category_ids": "string (Filter by category IDs, separated by comma)",
+      "account_ids": "string (Filter by account IDs, separated by comma)",
+      "tag_filter": "string (Filter by tags, e.g. type:tagid,tagid; another filter)",
+      "amount_filter": "string (Filter by amount)",
+      "keyword": "string (Filter by keyword)",
+      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
+      "start_time": "integer (Transaction list start unix time)",
+      "end_time": "integer (Transaction list end unix time)",
+      "with_pictures": "boolean (Whether to include transaction picture IDs)",
+      "trim_account": "boolean (Whether to return account IDs only)",
+      "trim_category": "boolean (Whether to return category IDs only)",
+      "trim_tag": "boolean (Whether to return tag IDs only)"
+    },
+    "PrettyResponse": {
+      "Type": "simple_array_to_markdown_table",
+      "Columns": [
+        "id",
+        "type",
+        "time",
+        "utcOffset",
+        "categoryId",
+        "sourceAccountId",
+        "sourceAmount",
+        "destinationAccountId",
+        "destinationAmount",
+        "tagIds",
+        "geoLocation",
+        "comment"
+      ]
+    }
+  },
+  {
+    "Name": "transactions-get",
+    "Description": "Retrieve one transaction by ID",
+    "Method": "GET",
+    "Path": "transactions/get.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [
+      "with_pictures"
+    ],
+    "ParamTypes": {
+      "id": "string",
+      "with_pictures": "boolean"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction ID)",
+      "with_pictures": "boolean (Whether to include transaction picture IDs)"
+    }
+  },
+  {
+    "Name": "transactions-add",
+    "Description": "Add a new transaction",
+    "Method": "POST",
+    "Path": "transactions/add.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "type",
+      "categoryId",
+      "time",
+      "utcOffset",
+      "sourceAccountId",
+      "sourceAmount"
+    ],
+    "OptionalParams": [
+      "destinationAccountId",
+      "destinationAmount",
+      "hideAmount",
+      "tagIds",
+      "pictureIds",
+      "comment",
+      "geoLocation",
+      "clientSessionId"
+    ],
+    "ParamTypes": {
+      "type": "integer",
+      "time": "integer",
+      "utcOffset": "integer",
+      "sourceAmount": "integer",
+      "destinationAmount": "integer",
+      "categoryId": "string",
+      "sourceAccountId": "string",
+      "destinationAccountId": "string",
+      "comment": "string",
+      "clientSessionId": "string",
+      "hideAmount": "boolean",
+      "tagIds": "string_array",
+      "pictureIds": "string_array",
+      "geoLocation": "geo_location"
+    },
+    "ParamDescriptions": {
+      "type": "integer (Transaction type, 1: Balance Modification, 2: Income, 3: Expense, 4: Transfer)",
+      "categoryId": "string (Transaction category ID; use 0 for balance modification)",
+      "time": "integer (Transaction unix time)",
+      "utcOffset": "integer (Transaction timezone offset minutes, e.g. 480 for UTC+8)",
+      "sourceAccountId": "string (Source account ID, supports account without sub-accounts or sub-account)",
+      "sourceAmount": "integer (Source amount, scaled by 100; 1234 means 12.34)",
+      "destinationAccountId": "string (Destination account ID for transfers)",
+      "destinationAmount": "integer (Destination amount for transfers, scaled by 100)",
+      "hideAmount": "boolean (Whether to hide amount)",
+      "tagIds": "string (Transaction tag IDs, separated by comma)",
+      "pictureIds": "string (Transaction picture IDs, separated by comma)",
+      "comment": "string (Transaction description)",
+      "geoLocation": "string (Transaction geographic location, format: longitude,latitude)",
+      "clientSessionId": "string (Client session ID for duplicate submission protection)"
+    }
+  },
+  {
+    "Name": "transactions-modify",
+    "Description": "Modify an existing transaction",
+    "Method": "POST",
+    "Path": "transactions/modify.json",
+    "RequiresTimezone": true,
+    "RequiredParams": [
+      "id",
+      "categoryId",
+      "time",
+      "utcOffset",
+      "sourceAccountId",
+      "sourceAmount"
+    ],
+    "OptionalParams": [
+      "destinationAccountId",
+      "destinationAmount",
+      "hideAmount",
+      "tagIds",
+      "pictureIds",
+      "comment",
+      "geoLocation"
+    ],
+    "ParamTypes": {
+      "time": "integer",
+      "utcOffset": "integer",
+      "sourceAmount": "integer",
+      "destinationAmount": "integer",
+      "id": "string",
+      "categoryId": "string",
+      "sourceAccountId": "string",
+      "destinationAccountId": "string",
+      "comment": "string",
+      "hideAmount": "boolean",
+      "tagIds": "string_array",
+      "pictureIds": "string_array",
+      "geoLocation": "geo_location"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction ID)",
+      "categoryId": "string (Transaction category ID; use 0 for balance modification)",
+      "time": "integer (Transaction unix time)",
+      "utcOffset": "integer (Transaction timezone offset minutes, e.g. 480 for UTC+8)",
+      "sourceAccountId": "string (Source account ID, supports account without sub-accounts or sub-account)",
+      "sourceAmount": "integer (Source amount, scaled by 100; 1234 means 12.34)",
+      "destinationAccountId": "string (Destination account ID for transfers)",
+      "destinationAmount": "integer (Destination amount for transfers, scaled by 100)",
+      "hideAmount": "boolean (Whether to hide amount)",
+      "tagIds": "string (Transaction tag IDs, separated by comma)",
+      "pictureIds": "string (Transaction picture IDs, separated by comma)",
+      "comment": "string (Transaction description)",
+      "geoLocation": "string (Transaction geographic location, format: longitude,latitude)"
+    }
+  },
+  {
+    "Name": "transactions-batch-update-category",
+    "Description": "Batch update transaction category",
+    "Method": "POST",
+    "Path": "transactions/batch_update/category.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "transactionIds",
+      "categoryId"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "transactionIds": "string_array",
+      "categoryId": "string"
+    },
+    "ParamDescriptions": {
+      "transactionIds": "string (Transaction IDs, separated by comma)",
+      "categoryId": "string (Transaction category ID; use 0 for balance modification)"
+    }
+  },
+  {
+    "Name": "transactions-batch-update-account",
+    "Description": "Batch update transaction account",
+    "Method": "POST",
+    "Path": "transactions/batch_update/account.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "transactionIds",
+      "accountId"
+    ],
+    "OptionalParams": [
+      "isDestinationAccount"
+    ],
+    "ParamTypes": {
+      "transactionIds": "string_array",
+      "accountId": "string",
+      "isDestinationAccount": "boolean"
+    },
+    "ParamDescriptions": {
+      "transactionIds": "string (Transaction IDs, separated by comma)",
+      "accountId": "string (Target account ID)",
+      "isDestinationAccount": "boolean (Whether to update destination account for transfer transactions)"
+    }
+  },
+  {
+    "Name": "transactions-batch-add-tags",
+    "Description": "Batch add tags to transactions",
+    "Method": "POST",
+    "Path": "transactions/batch_update/tag/add.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "transactionIds",
+      "tagIds"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "transactionIds": "string_array",
+      "tagIds": "string_array"
+    },
+    "ParamDescriptions": {
+      "transactionIds": "string (Transaction IDs, separated by comma)",
+      "tagIds": "string (Transaction tag IDs, separated by comma)"
+    }
+  },
+  {
+    "Name": "transactions-batch-remove-tags",
+    "Description": "Batch remove tags from transactions",
+    "Method": "POST",
+    "Path": "transactions/batch_update/tag/remove.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "transactionIds",
+      "tagIds"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "transactionIds": "string_array",
+      "tagIds": "string_array"
+    },
+    "ParamDescriptions": {
+      "transactionIds": "string (Transaction IDs, separated by comma)",
+      "tagIds": "string (Transaction tag IDs, separated by comma)"
+    }
+  },
+  {
+    "Name": "transactions-batch-clear-tags",
+    "Description": "Batch clear all tags from transactions",
+    "Method": "POST",
+    "Path": "transactions/batch_update/tag/clear.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "transactionIds"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "transactionIds": "string_array"
+    },
+    "ParamDescriptions": {
+      "transactionIds": "string (Transaction IDs, separated by comma)"
+    }
+  },
+  {
+    "Name": "transactions-move-all",
+    "Description": "Move all transactions from one account to another",
+    "Method": "POST",
+    "Path": "transactions/move/all.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "fromAccountId",
+      "toAccountId"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "fromAccountId": "string",
+      "toAccountId": "string"
+    },
+    "ParamDescriptions": {
+      "fromAccountId": "string (Source account ID)",
+      "toAccountId": "string (Destination account ID)"
+    }
+  },
+  {
+    "Name": "transactions-delete",
+    "Description": "Delete one transaction",
+    "Method": "POST",
+    "Path": "transactions/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "id"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "id": "string"
+    },
+    "ParamDescriptions": {
+      "id": "string (Transaction ID)"
+    }
+  },
+  {
+    "Name": "transactions-batch-delete",
+    "Description": "Batch delete transactions",
+    "Method": "POST",
+    "Path": "transactions/batch_delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "ids"
+    ],
+    "OptionalParams": [
+      "password"
+    ],
+    "ParamTypes": {
+      "ids": "string_array",
+      "password": "string"
+    },
+    "ParamDescriptions": {
+      "ids": "string (Transaction IDs, separated by comma)",
+      "password": "string (Current user password, if server requires confirmation)"
+    }
+  },
+  {
+    "Name": "exchangerates-latest",
+    "Description": "Retrieve the latest exchange rate data",
+    "Method": "GET",
+    "Path": "exchange_rates/latest.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [],
+    "ParamTypes": {},
+    "ParamDescriptions": {},
+    "PrettyResponse": {
+      "Type": "nested_array_to_markdown_table",
+      "Columns": [
+        "currency",
+        "rate"
+      ],
+      "DataPath": "exchangeRates",
+      "Metadata": [
+        {
+          "Field": "dataSource",
+          "Label": "Data Source"
+        },
+        {
+          "Field": "baseCurrency",
+          "Label": "Base Currency"
+        },
+        {
+          "Field": "updateTime",
+          "Label": "Update Time"
+        }
+      ]
+    }
+  },
+  {
+    "Name": "exchangerates-custom-update",
+    "Description": "Update a user custom exchange rate",
+    "Method": "POST",
+    "Path": "exchange_rates/user_custom/update.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "currency",
+      "rate"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "currency": "string",
+      "rate": "string"
+    },
+    "ParamDescriptions": {
+      "currency": "string (Currency code, ISO 4217)",
+      "rate": "string (Custom exchange rate)"
+    }
+  },
+  {
+    "Name": "exchangerates-custom-delete",
+    "Description": "Delete a user custom exchange rate",
+    "Method": "POST",
+    "Path": "exchange_rates/user_custom/delete.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [
+      "currency"
+    ],
+    "OptionalParams": [],
+    "ParamTypes": {
+      "currency": "string"
+    },
+    "ParamDescriptions": {
+      "currency": "string (Currency code, ISO 4217)"
+    }
+  },
+  {
+    "Name": "server-version",
+    "Description": "Retrieve ezBookkeeping server version information",
+    "Method": "GET",
+    "Path": "systems/version.json",
+    "RequiresTimezone": false,
+    "RequiredParams": [],
+    "OptionalParams": [],
+    "ParamTypes": {},
+    "ParamDescriptions": {}
+  }
+]

--- a/skills/ezbookkeeping/scripts/ebktools.ps1
+++ b/skills/ezbookkeeping/scripts/ebktools.ps1
@@ -16,6 +16,9 @@ param(
     [Parameter(Mandatory=$false)]
     [switch]$rawResponse = $false,
 
+    [Parameter(Mandatory=$false)]
+    [switch]$dryRun = $false,
+
     [Parameter(ValueFromRemainingArguments=$true)]
     [string[]]$CommandArgs
 )
@@ -23,679 +26,22 @@ param(
 $script:EBKTOOL_SERVER_BASEURL = $env:EBKTOOL_SERVER_BASEURL
 $script:EBKTOOL_TOKEN = $env:EBKTOOL_TOKEN
 
-# API Configuration Structure
-$API_CONFIGS = @(
-    @{
-        Name = "tokens-list"
-        Description = "Retrieve all sessions for the current user"
-        Method = "GET"
-        Path = "tokens/list.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "["
-            "  {"
-            "    `"tokenId`": `"string (Token ID)`","
-            "    `"tokenType`": `"integer (Token type, 1: Normal Token, 5: MCP Token, 8: API Token)`","
-            "    `"userAgent`": `"string (The User Agent when the session created)`","
-            "    `"lastSeen`": `"integer (Last refresh unix time of the session)`","
-            "    `"isCurrent`": `"boolean (Whether the session is current)`""
-            "  }"
-            "]"
-        )
-        PrettyResponse = @{
-            Type = "simple_array_to_markdown_table"
-            Columns = @("tokenId", "tokenType", "userAgent", "lastSeen", "isCurrent")
-        }
-    }
-    @{
-        Name = "tokens-revoke"
-        Description = "Revoke a specified token"
-        Method = "POST"
-        Path = "tokens/revoke.json"
-        RequiresTimezone = $false
-        RequiredParams = @("tokenId")
-        OptionalParams = @()
-        ParamTypes = @{
-            "tokenId" = "string"
-        }
-        ParamDescriptions = @{
-            "tokenId" = "string (Token ID)"
-        }
-        ResponseStructure = @(
-            "boolean (Whether the token is revoked successfully)"
-        )
-    }
-    @{
-        Name = "accounts-list"
-        Description = "Retrieve all account information"
-        Method = "GET"
-        Path = "accounts/list.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "["
-            "  {"
-            "    `"id`": `"string (Account ID)`","
-            "    `"name`": `"string (Account name)`","
-            "    `"parentId`": `"string (Parent account ID, 0 for primary account)`","
-            "    `"category`": `"integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)`","
-            "    `"type`": `"integer (Account type, 1: Single Account, 2: Multiple Sub-accounts)`","
-            "    `"icon`": `"string (Account icon ID)`","
-            "    `"color`": `"string (Account icon color, hex color code RRGGBB)`","
-            "    `"currency`": `"string (Account currency code)`","
-            "    `"balance`": `"integer (Account balance, supports up to two decimals. For example, a value of '1234' represents an amount of '12.34')`","
-            "    `"comment`": `"string (Account description)`","
-            "    `"creditCardStatementDate`": `"integer (The statement date of the credit card account)`","
-            "    `"displayOrder`": `"integer (The display order of the account)`","
-            "    `"isAsset`": `"boolean (Whether the account is an asset account)`","
-            "    `"isLiability`": `"boolean (Whether the account is a liability account)`","
-            "    `"hidden`": `"boolean (Whether the account is hidden)`","
-            "    `"subAccounts`": [`"each sub-account object like an account object`"]"
-            "  }"
-            "]"
-        )
-        PrettyResponse = @{
-            Type = "hierarchical_array_to_markdown_table"
-            Columns = @("category", "type", "parentId", "id", "name", "currency", "balance", "hidden", "comment")
-            ChildKey = "subAccounts"
-        }
-    }
-    @{
-        Name = "accounts-add"
-        Description = "Add a new account"
-        Method = "POST"
-        Path = "accounts/add.json"
-        RequiresTimezone = $true
-        RequiredParams = @("name", "category", "type", "icon", "color", "currency")
-        OptionalParams = @("balance", "balanceTime", "comment", "creditCardStatementDate")
-        ParamTypes = @{
-            "name" = "string"
-            "category" = "integer"
-            "type" = "integer"
-            "icon" = "string"
-            "color" = "string"
-            "currency" = "string"
-            "balance" = "integer"
-            "balanceTime" = "integer"
-            "comment" = "string"
-            "creditCardStatementDate" = "integer"
-        }
-        ParamDescriptions = @{
-            "name" = "string (Account name)"
-            "category" = "integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)"
-            "type" = "integer (Account type, 1: Single Account, 2: Multiple Sub-accounts)"
-            "icon" = "string (Account icon ID)"
-            "color" = "string (Account icon color, hex color code RRGGBB)"
-            "currency" = "string (Account currency code, ISO 4217 code, `"---`" for the parent account)"
-            "balance" = "integer (Account balance, supports up to two decimals. For example, a value of `"1234`" represents an amount of `"12.34`". Liability account should set to negative amount)"
-            "balanceTime" = "integer (The unix time when the account balance is the set value. This field is required when balance is set)"
-            "comment" = "string (Account description)"
-            "creditCardStatementDate" = "integer (The statement date of the credit card account)"
-        }
-        ResponseStructure = @(
-            "{"
-            "  `"id`": `"string (Account ID)`","
-            "  `"name`": `"string (Account name)`","
-            "  `"parentId`": `"string (Parent account ID)`","
-            "  `"category`": `"integer (Account category)`","
-            "  `"type`": `"integer (Account type)`","
-            "  `"icon`": `"string (Account icon ID)`","
-            "  `"color`": `"string (Account icon color)`","
-            "  `"currency`": `"string (Account currency code)`","
-            "  `"balance`": `"integer (Account balance)`","
-            "  `"comment`": `"string (Account description)`","
-            "  `"creditCardStatementDate`": `"integer (The statement date of the credit card account)`","
-            "  `"displayOrder`": `"integer (The display order of the account)`","
-            "  `"isAsset`": `"boolean (Whether the account is an asset account)`","
-            "  `"isLiability`": `"boolean (Whether the account is a liability account)`","
-            "  `"hidden`": `"boolean (Whether the account is hidden)`","
-            "  `"subAccounts`": [`"every sub-account object like account object`"]"
-            "}"
-        )
-    }
-    @{
-        Name = "transaction-categories-list"
-        Description = "Retrieve all available transaction categories"
-        Method = "GET"
-        Path = "transaction/categories/list.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "{"
-            "  `"transaction category type (1: Income, 2: Expense, 3:Transfer)`": ["
-            "    {"
-            "      `"id`": `"string (Transaction category ID)`","
-            "      `"name`": `"string (Transaction category name)`","
-            "      `"parentId`": `"string (Parent transaction category ID, 0 for primary category)`","
-            "      `"type`": `"integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)`","
-            "      `"icon`": `"string (Transaction category icon ID)`","
-            "      `"color`": `"string (Transaction category icon color, hex color code RRGGBB)`","
-            "      `"comment`": `"string (Transaction category description)`","
-            "      `"displayOrder`": `"integer (The display order of the transaction category)`","
-            "      `"hidden`": `"boolean (Whether the transaction category is hidden)`","
-            "      `"subCategories`": [`"each sub-category object like a transaction category object`"]"
-            "    }"
-            "  ]"
-            "}"
-        )
-        PrettyResponse = @{
-            Type = "hierarchical_object_to_markdown_table"
-            Columns = @("type", "parentId", "id", "name", "hidden", "comment")
-            ChildKey = "subCategories"
-        }
-    }
-    @{
-        Name = "transaction-categories-add"
-        Description = "Add a new transaction category"
-        Method = "POST"
-        Path = "transaction/categories/add.json"
-        RequiresTimezone = $false
-        RequiredParams = @("name", "type", "icon", "color")
-        OptionalParams = @("parentId", "comment")
-        ParamTypes = @{
-            "name" = "string"
-            "type" = "integer"
-            "parentId" = "string"
-            "icon" = "string"
-            "color" = "string"
-            "comment" = "string"
-        }
-        ParamDescriptions = @{
-            "name" = "string (Transaction category name)"
-            "type" = "integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)"
-            "parentId" = "string (Parent transaction category ID, 0 for primary category)"
-            "icon" = "string (Transaction category icon ID)"
-            "color" = "string (Transaction category icon color, hex color code RRGGBB)"
-            "comment" = "string (Transaction category description)"
-        }
-        ResponseStructure = @(
-            "{"
-            "  `"id`": `"string (Transaction category ID)`","
-            "  `"name`": `"string (Transaction category name)`","
-            "  `"parentId`": `"string (Parent transaction category ID)`","
-            "  `"type`": `"integer (Transaction category type)`","
-            "  `"icon`": `"string (Transaction category icon ID)`","
-            "  `"color`": `"string (Transaction category icon color)`","
-            "  `"comment`": `"string (Transaction category description)`","
-            "  `"displayOrder`": `"integer (The display order of the transaction category)`","
-            "  `"hidden`": `"boolean (Whether the transaction category is hidden)`","
-            "  `"subCategories`": [`"each sub-category object like a transaction category object`"]"
-            "}"
-        )
-    }
-    @{
-        Name = "transaction-tags-list"
-        Description = "Retrieve all available transaction tags"
-        Method = "GET"
-        Path = "transaction/tags/list.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "["
-            "  {"
-            "    `"id`": `"string (Transaction tag ID)`","
-            "    `"name`": `"string (Transaction tag name)`","
-            "    `"groupId`": `"string (Transaction tag group ID)`","
-            "    `"displayOrder`": `"integer (The display order of the transaction tag)`","
-            "    `"hidden`": `"boolean (Whether the transaction tag is hidden)`""
-            "  }"
-            "]"
-        )
-        PrettyResponse = @{
-            Type = "simple_array_to_markdown_table"
-            Columns = @("groupId", "id", "name", "hidden")
-        }
-    }
-    @{
-        Name = "transaction-tags-add"
-        Description = "Add a new transaction tag"
-        Method = "POST"
-        Path = "transaction/tags/add.json"
-        RequiresTimezone = $false
-        RequiredParams = @("name")
-        OptionalParams = @("groupId")
-        ParamTypes = @{
-            "name" = "string"
-            "groupId" = "string"
-        }
-        ParamDescriptions = @{
-            "name" = "string (Transaction tag name)"
-            "groupId" = "string (Transaction tag group ID, 0 means default group)"
-        }
-        ResponseStructure = @(
-            "{"
-            "  `"id`": `"string (Transaction tag ID)`","
-            "  `"name`": `"string (Transaction tag name)`","
-            "  `"groupId`": `"string (Transaction tag group ID)`","
-            "  `"displayOrder`": `"integer (The display order of the transaction tag)`","
-            "  `"hidden`": `"boolean (Whether the transaction tag is hidden)`""
-            "}"
-        )
-    }
-    @{
-        Name = "transactions-list"
-        Description = "Retrieve transaction data based on specified query criteria (with pagination support)"
-        Method = "GET"
-        Path = "transactions/list.json"
-        RequiresTimezone = $true
-        RequiredParams = @("count")
-        OptionalParams = @("type", "category_ids", "account_ids", "tag_filter", "amount_filter", "keyword", "must_have_pictures", "max_time", "min_time", "page", "with_count", "with_pictures", "trim_account", "trim_category", "trim_tag")
-        ParamTypes = @{
-            "count" = "integer"
-            "type" = "integer"
-            "category_ids" = "string"
-            "account_ids" = "string"
-            "tag_filter" = "string"
-            "amount_filter" = "string"
-            "keyword" = "string"
-            "must_have_pictures" = "boolean"
-            "max_time" = "integer"
-            "min_time" = "integer"
-            "page" = "integer"
-            "with_count" = "boolean"
-            "with_pictures" = "boolean"
-            "trim_account" = "boolean"
-            "trim_category" = "boolean"
-            "trim_tag" = "boolean"
-        }
-        ParamDescriptions = @{
-            "count" = "integer (The count of transactions per page, maximum is 50)"
-            "type" = "integer (Filter transaction by type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)"
-            "category_ids" = "string (Filter by category IDs, separated by comma)"
-            "account_ids" = "string (Filter by account IDs, separated by comma)"
-            "tag_filter" = "string (Filter by tags)"
-            "amount_filter" = "string (Filter by amount)"
-            "keyword" = "string (Filter by keyword)"
-            "must_have_pictures" = "boolean (Whether to only get transactions with pictures)"
-            "max_time" = "integer (The maximum time sequence ID, Set to 0 for latest)"
-            "min_time" = "integer (The minimum time sequence ID)"
-            "page" = "integer (Specified page integer)"
-            "with_count" = "boolean (Whether to get total count)"
-            "with_pictures" = "boolean (Whether to get picture IDs)"
-            "trim_account" = "boolean (Whether to get account ID only)"
-            "trim_category" = "boolean (Whether to get category ID only)"
-            "trim_tag" = "boolean (Whether to get tag IDs only)"
-        }
-        ResponseStructure = @(
-            "{"
-            "  `"items`": ["
-            "    {"
-            "      `"id`": `"string (Transaction ID)`","
-            "      `"timeSequenceId`": `"string (Transaction time sequence ID)`","
-            "      `"type`": `"integer (Transaction type)`","
-            "      `"categoryId`": `"string (Transaction category ID)`","
-            "      `"category`": `"object (Transaction category object)`","
-            "      `"time`": `"integer (Transaction unix time)`","
-            "      `"utcOffset`": `"integer (Transaction time zone offset minutes)`","
-            "      `"sourceAccountId`": `"string (Source account ID)`","
-            "      `"sourceAccount`": `"object (Source account object)`","
-            "      `"destinationAccountId`": `"string (Destination account ID)`","
-            "      `"destinationAccount`": `"object (Destination account object)`","
-            "      `"sourceAmount`": `"integer (Source amount, supports up to two decimals. For example, a value of '1234' represents an amount of '12.34')`","
-            "      `"destinationAmount`": `"integer (Destination amount, supports up to two decimals. For example, a value of '1234' represents an amount of '12.34')`","
-            "      `"hideAmount`": `"boolean (Whether to hide the amount)`","
-            "      `"tagIds`": [`"each string representing a transaction tag ID`"],"
-            "      `"tags`": [`"each object representing a transaction tag object`"],"
-            "      `"pictures`": [`"each object representing a transaction picture object`"],"
-            "      `"comment`": `"string (Transaction description)`","
-            "      `"geoLocation`": `"object (Transaction geographic location)`","
-            "      `"editable`": `"boolean (Whether the transaction is editable)`""
-            "    }"
-            "  ],"
-            "  `"nextTimeSequenceId`": `"integer (The next cursor 'max_time' parameter when requesting older data)`","
-            "  `"totalCount`": `"integer (The total count of transactions)`""
-            "}"
-        )
-        PrettyResponse = @{
-            Type = "nested_array_to_markdown_table"
-            Columns = @("id", "type", "time", "utcOffset", "categoryId", "sourceAccountId", "sourceAmount", "destinationAccountId", "destinationAmount", "tagIds", "geoLocation", "comment")
-            DataPath = "items"
-            Metadata = @(
-                @{ Field = "totalCount"; Label = "Total Count" },
-                @{ Field = "nextTimeSequenceId"; Label = "Next Time Sequence ID" }
-            )
-        }
-    }
-    @{
-        Name = "transactions-list-all"
-        Description = "Retrieve all transaction data matching the specified query criteria"
-        Method = "GET"
-        Path = "transactions/list/all.json"
-        RequiresTimezone = $true
-        RequiredParams = @()
-        OptionalParams = @("type", "category_ids", "account_ids", "tag_filter", "amount_filter", "keyword", "must_have_pictures", "start_time", "end_time", "with_pictures", "trim_account", "trim_category", "trim_tag")
-        ParamTypes = @{
-            "type" = "integer"
-            "category_ids" = "string"
-            "account_ids" = "string"
-            "tag_filter" = "string"
-            "amount_filter" = "string"
-            "keyword" = "string"
-            "must_have_pictures" = "boolean"
-            "start_time" = "integer"
-            "end_time" = "integer"
-            "with_pictures" = "boolean"
-            "trim_account" = "boolean"
-            "trim_category" = "boolean"
-            "trim_tag" = "boolean"
-        }
-        ParamDescriptions = @{
-            "type" = "integer (Filter transaction by type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)"
-            "category_ids" = "string (Filter by category IDs, separated by comma)"
-            "account_ids" = "string (Filter by account IDs, separated by comma)"
-            "tag_filter" = "string (Filter by tags)"
-            "amount_filter" = "string (Filter by amount)"
-            "keyword" = "string (Filter by keyword)"
-            "must_have_pictures" = "boolean (Whether to only get transactions with pictures)"
-            "start_time" = "integer (Transaction list start unix time)"
-            "end_time" = "integer (Transaction list end unix time)"
-            "with_pictures" = "boolean (Whether to get picture IDs)"
-            "trim_account" = "boolean (Whether to get account ID only)"
-            "trim_category" = "boolean (Whether to get category ID only)"
-            "trim_tag" = "boolean (Whether to get tag IDs only)"
-        }
-        ResponseStructure = @(
-            "["
-            "  {"
-            "    `"id`": `"string (Transaction ID)`","
-            "    `"timeSequenceId`": `"string (Transaction time sequence ID)`","
-            "    `"type`": `"integer (Transaction type)`","
-            "    `"categoryId`": `"string (Transaction category ID)`","
-            "    `"category`": `"object (Transaction category object)`","
-            "    `"time`": `"integer (Transaction unix time)`","
-            "    `"utcOffset`": `"integer (Transaction time zone offset minutes)`","
-            "    `"sourceAccountId`": `"string (Source account ID)`","
-            "    `"sourceAccount`": `"object (Source account object)`","
-            "    `"destinationAccountId`": `"string (Destination account ID)`","
-            "    `"destinationAccount`": `"object (Destination account object)`","
-            "    `"sourceAmount`": `"integer (Source amount, supports up to two decimals. For example, a value of '1234' represents an amount of '12.34')`","
-            "    `"destinationAmount`": `"integer (Destination amount, supports up to two decimals. For example, a value of '1234' represents an amount of '12.34')`","
-            "    `"hideAmount`": `"boolean (Whether to hide the amount)`","
-            "    `"tagIds`": [`"each string representing a transaction tag ID`"],"
-            "    `"tags`": [`"each object representing a transaction tag object`"],"
-            "    `"pictures`": [`"each object representing a transaction picture object`"],"
-            "    `"comment`": `"string (Transaction description)`","
-            "    `"geoLocation`": `"object (Transaction geographic location)`","
-            "    `"editable`": `"boolean (Whether the transaction is editable)`""
-            "  }"
-            "]"
-        )
-        PrettyResponse = @{
-            Type = "simple_array_to_markdown_table"
-            Columns = @("id", "type", "time", "utcOffset", "categoryId", "sourceAccountId", "sourceAmount", "destinationAccountId", "destinationAmount", "tagIds", "geoLocation", "comment")
-        }
-    }
-    @{
-        Name = "transactions-add"
-        Description = "Add a new transaction"
-        Method = "POST"
-        Path = "transactions/add.json"
-        RequiresTimezone = $true
-        RequiredParams = @("type", "categoryId", "time", "utcOffset", "sourceAccountId", "sourceAmount")
-        OptionalParams = @("destinationAccountId", "destinationAmount", "hideAmount", "tagIds", "pictureIds", "comment", "geoLocation")
-        ParamTypes = @{
-            "type" = "integer"
-            "categoryId" = "string"
-            "time" = "integer"
-            "utcOffset" = "integer"
-            "sourceAccountId" = "string"
-            "sourceAmount" = "integer"
-            "destinationAccountId" = "string"
-            "destinationAmount" = "integer"
-            "hideAmount" = "boolean"
-            "tagIds" = "string_array"
-            "pictureIds" = "string_array"
-            "comment" = "string"
-            "geoLocation" = "geo_location"
-        }
-        ParamDescriptions = @{
-            "type" = "integer (Transaction type, 1: Balance Modification, 2: Income, 3: Expense, 4: Transfer)"
-            "categoryId" = "string (Transaction category ID, supports secondary category)"
-            "time" = "integer (Transaction unix time)"
-            "utcOffset" = "integer (Transaction time zone offset minutes)"
-            "sourceAccountId" = "string (Source account ID, supports account without sub-accounts or sub-account)"
-            "sourceAmount" = "integer (Source amount, supports up to two decimals. For example, a value of `"1234`" represents an amount of `"12.34`")"
-            "destinationAccountId" = "string (Destination account ID, supports account without sub-accounts or sub-account)"
-            "destinationAmount" = "integer (Destination amount, supports up to two decimals. For example, a value of `"1234`" represents an amount of `"12.34`")"
-            "hideAmount" = "boolean (Whether to hide amount)"
-            "tagIds" = "string (Transaction tag IDs, separated by comma, e.g. `"tagid1,tagid2`")"
-            "pictureIds" = "string (Transaction picture IDs, separated by comma, e.g. `"picid1,picid2`")"
-            "comment" = "string (Transaction description)"
-            "geoLocation" = "string (Transaction geographic location, format: longitude,latitude, e.g. `"116.33,39.93`")"
-        }
-        ResponseStructure = @(
-            "{"
-            "  `"id`": `"string (Transaction ID)`","
-            "  `"timeSequenceId`": `"string (Transaction time sequence ID)`","
-            "  `"type`": `"integer (Transaction type)`","
-            "  `"categoryId`": `"string (Transaction category ID)`","
-            "  `"category`": `"object (Transaction category object)`","
-            "  `"time`": `"integer (Transaction unix time)`","
-            "  `"utcOffset`": `"integer (Transaction time zone offset minutes)`","
-            "  `"sourceAccountId`": `"string (Source account ID)`","
-            "  `"sourceAccount`": `"object (Source account object)`","
-            "  `"destinationAccountId`": `"string (Destination account ID)`","
-            "  `"destinationAccount`": `"object (Destination account object)`","
-            "  `"sourceAmount`": `"integer (Source amount)`","
-            "  `"destinationAmount`": `"integer (Destination amount)`","
-            "  `"hideAmount`": `"boolean (Whether to hide the amount)`","
-            "  `"tagIds`": [`"each string representing a transaction tag ID`"],"
-            "  `"tags`": [`"each object representing a transaction tag object`"],"
-            "  `"pictures`": [`"each object representing a transaction picture object`"],"
-            "  `"comment`": `"string (Transaction description)`","
-            "  `"geoLocation`": `"object (Transaction geographic location)`","
-            "  `"editable`": `"boolean (Whether the transaction is editable)`""
-            "}"
-        )
-    }
-    @{
-        Name = "exchangerates-latest"
-        Description = "Retrieve the latest exchange rate data"
-        Method = "GET"
-        Path = "exchange_rates/latest.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "{"
-            "  `"dataSource`": `"string (Exchange rate data source name)`","
-            "  `"referenceUrl`": `"string (Exchange rate data reference URL)`","
-            "  `"updateTime`": `"integer (Exchange rate data update unix time)`","
-            "  `"baseCurrency`": `"string (Base currency code)`","
-            "  `"exchangeRates`": ["
-            "    {"
-            "      `"currency`": `"string (Currency code)`","
-            "      `"rate`": `"string (Exchange rate, 1 unit of base currency equals to how many units of this currency)`""
-            "    }"
-            "  ]"
-            "}"
-        )
-        PrettyResponse = @{
-            Type = "nested_array_to_markdown_table"
-            Columns = @("currency", "rate")
-            DataPath = "exchangeRates"
-            Metadata = @(
-                @{ Field = "dataSource"; Label = "Data Source" },
-                @{ Field = "baseCurrency"; Label = "Base Currency" },
-                @{ Field = "updateTime"; Label = "Update Time" }
-            )
-        }
-    }
-    @{
-        Name = "server-version"
-        Description = "Retrieve ezBookkeeping server version information"
-        Method = "GET"
-        Path = "systems/version.json"
-        RequiresTimezone = $false
-        RequiredParams = @()
-        OptionalParams = @()
-        ParamTypes = @{}
-        ParamDescriptions = @{}
-        ResponseStructure = @(
-            "{"
-            "  `"version`": `"string (Server version)`","
-            "  `"commitHash`": `"string (Git commit hash)`""
-            "}"
-        )
-    }
-)
+$script:API_CONFIGS = @()
 
-# Reference: https://github.com/unicode-org/cldr/blob/main/common/supplemental/windowsZones.xml
-$TIMEZONE_IANA_NAMES = @{
-    "Dateline Standard Time" = "Etc/GMT+12"
-    "UTC-11" = "Etc/GMT+11"
-    "Aleutian Standard Time" = "America/Adak"
-    "Hawaiian Standard Time" = "Pacific/Honolulu"
-    "Marquesas Standard Time" = "Pacific/Marquesas"
-    "Alaskan Standard Time" = "America/Anchorage"
-    "UTC-09" = "Etc/GMT+9"
-    "Pacific Standard Time (Mexico)" = "America/Tijuana"
-    "UTC-08" = "Etc/GMT+8"
-    "Pacific Standard Time" = "America/Los_Angeles"
-    "US Mountain Standard Time" = "America/Phoenix"
-    "Mountain Standard Time (Mexico)" = "America/Mazatlan"
-    "Mountain Standard Time" = "America/Denver"
-    "Yukon Standard Time" = "America/Whitehorse"
-    "Central America Standard Time" = "America/Guatemala"
-    "Central Standard Time" = "America/Chicago"
-    "Easter Island Standard Time" = "Pacific/Easter"
-    "Central Standard Time (Mexico)" = "America/Mexico_City"
-    "Canada Central Standard Time" = "America/Regina"
-    "SA Pacific Standard Time" = "America/Bogota"
-    "Eastern Standard Time (Mexico)" = "America/Cancun"
-    "Eastern Standard Time" = "America/New_York"
-    "Haiti Standard Time" = "America/Port-au-Prince"
-    "Cuba Standard Time" = "America/Havana"
-    "US Eastern Standard Time" = "America/Indianapolis"
-    "Turks And Caicos Standard Time" = "America/Grand_Turk"
-    "Paraguay Standard Time" = "America/Asuncion"
-    "Atlantic Standard Time" = "America/Halifax"
-    "Venezuela Standard Time" = "America/Caracas"
-    "Central Brazilian Standard Time" = "America/Cuiaba"
-    "SA Western Standard Time" = "America/La_Paz"
-    "Pacific SA Standard Time" = "America/Santiago"
-    "Newfoundland Standard Time" = "America/St_Johns"
-    "Tocantins Standard Time" = "America/Araguaina"
-    "E. South America Standard Time" = "America/Sao_Paulo"
-    "SA Eastern Standard Time" = "America/Cayenne"
-    "Argentina Standard Time" = "America/Buenos_Aires"
-    "Greenland Standard Time" = "America/Godthab"
-    "Montevideo Standard Time" = "America/Montevideo"
-    "Magallanes Standard Time" = "America/Punta_Arenas"
-    "Saint Pierre Standard Time" = "America/Miquelon"
-    "Bahia Standard Time" = "America/Bahia"
-    "UTC-02" = "Etc/GMT+2"
-    "Azores Standard Time" = "Atlantic/Azores"
-    "Cape Verde Standard Time" = "Atlantic/Cape_Verde"
-    "UTC" = "Etc/UTC"
-    "GMT Standard Time" = "Europe/London"
-    "Greenwich Standard Time" = "Atlantic/Reykjavik"
-    "Sao Tome Standard Time" = "Africa/Sao_Tome"
-    "Morocco Standard Time" = "Africa/Casablanca"
-    "W. Europe Standard Time" = "Europe/Berlin"
-    "Central Europe Standard Time" = "Europe/Budapest"
-    "Romance Standard Time" = "Europe/Paris"
-    "Central European Standard Time" = "Europe/Warsaw"
-    "W. Central Africa Standard Time" = "Africa/Lagos"
-    "Jordan Standard Time" = "Asia/Amman"
-    "GTB Standard Time" = "Europe/Bucharest"
-    "Middle East Standard Time" = "Asia/Beirut"
-    "Egypt Standard Time" = "Africa/Cairo"
-    "E. Europe Standard Time" = "Europe/Chisinau"
-    "Syria Standard Time" = "Asia/Damascus"
-    "West Bank Standard Time" = "Asia/Hebron"
-    "South Africa Standard Time" = "Africa/Johannesburg"
-    "FLE Standard Time" = "Europe/Kiev"
-    "Israel Standard Time" = "Asia/Jerusalem"
-    "South Sudan Standard Time" = "Africa/Juba"
-    "Kaliningrad Standard Time" = "Europe/Kaliningrad"
-    "Sudan Standard Time" = "Africa/Khartoum"
-    "Libya Standard Time" = "Africa/Tripoli"
-    "Namibia Standard Time" = "Africa/Windhoek"
-    "Arabic Standard Time" = "Asia/Baghdad"
-    "Turkey Standard Time" = "Europe/Istanbul"
-    "Arab Standard Time" = "Asia/Riyadh"
-    "Belarus Standard Time" = "Europe/Minsk"
-    "Russian Standard Time" = "Europe/Moscow"
-    "E. Africa Standard Time" = "Africa/Nairobi"
-    "Iran Standard Time" = "Asia/Tehran"
-    "Arabian Standard Time" = "Asia/Dubai"
-    "Astrakhan Standard Time" = "Europe/Astrakhan"
-    "Azerbaijan Standard Time" = "Asia/Baku"
-    "Russia Time Zone 3" = "Europe/Samara"
-    "Mauritius Standard Time" = "Indian/Mauritius"
-    "Saratov Standard Time" = "Europe/Saratov"
-    "Georgian Standard Time" = "Asia/Tbilisi"
-    "Volgograd Standard Time" = "Europe/Volgograd"
-    "Caucasus Standard Time" = "Asia/Yerevan"
-    "Afghanistan Standard Time" = "Asia/Kabul"
-    "West Asia Standard Time" = "Asia/Tashkent"
-    "Ekaterinburg Standard Time" = "Asia/Yekaterinburg"
-    "Pakistan Standard Time" = "Asia/Karachi"
-    "Qyzylorda Standard Time" = "Asia/Qyzylorda"
-    "India Standard Time" = "Asia/Calcutta"
-    "Sri Lanka Standard Time" = "Asia/Colombo"
-    "Nepal Standard Time" = "Asia/Katmandu"
-    "Central Asia Standard Time" = "Asia/Bishkek"
-    "Bangladesh Standard Time" = "Asia/Dhaka"
-    "Omsk Standard Time" = "Asia/Omsk"
-    "Myanmar Standard Time" = "Asia/Rangoon"
-    "SE Asia Standard Time" = "Asia/Bangkok"
-    "Altai Standard Time" = "Asia/Barnaul"
-    "W. Mongolia Standard Time" = "Asia/Hovd"
-    "North Asia Standard Time" = "Asia/Krasnoyarsk"
-    "N. Central Asia Standard Time" = "Asia/Novosibirsk"
-    "Tomsk Standard Time" = "Asia/Tomsk"
-    "China Standard Time" = "Asia/Shanghai"
-    "North Asia East Standard Time" = "Asia/Irkutsk"
-    "Singapore Standard Time" = "Asia/Singapore"
-    "W. Australia Standard Time" = "Australia/Perth"
-    "Taipei Standard Time" = "Asia/Taipei"
-    "Ulaanbaatar Standard Time" = "Asia/Ulaanbaatar"
-    "Aus Central W. Standard Time" = "Australia/Eucla"
-    "Transbaikal Standard Time" = "Asia/Chita"
-    "Tokyo Standard Time" = "Asia/Tokyo"
-    "North Korea Standard Time" = "Asia/Pyongyang"
-    "Korea Standard Time" = "Asia/Seoul"
-    "Yakutsk Standard Time" = "Asia/Yakutsk"
-    "Cen. Australia Standard Time" = "Australia/Adelaide"
-    "AUS Central Standard Time" = "Australia/Darwin"
-    "E. Australia Standard Time" = "Australia/Brisbane"
-    "AUS Eastern Standard Time" = "Australia/Sydney"
-    "West Pacific Standard Time" = "Pacific/Port_Moresby"
-    "Tasmania Standard Time" = "Australia/Hobart"
-    "Vladivostok Standard Time" = "Asia/Vladivostok"
-    "Lord Howe Standard Time" = "Australia/Lord_Howe"
-    "Bougainville Standard Time" = "Pacific/Bougainville"
-    "Russia Time Zone 10" = "Asia/Srednekolymsk"
-    "Magadan Standard Time" = "Asia/Magadan"
-    "Norfolk Standard Time" = "Pacific/Norfolk"
-    "Sakhalin Standard Time" = "Asia/Sakhalin"
-    "Central Pacific Standard Time" = "Pacific/Guadalcanal"
-    "Russia Time Zone 11" = "Asia/Kamchatka"
-    "New Zealand Standard Time" = "Pacific/Auckland"
-    "UTC+12" = "Etc/GMT-12"
-    "Fiji Standard Time" = "Pacific/Fiji"
-    "Chatham Islands Standard Time" = "Pacific/Chatham"
-    "UTC+13" = "Etc/GMT-13"
-    "Tonga Standard Time" = "Pacific/Tongatapu"
-    "Samoa Standard Time" = "Pacific/Apia"
-    "Line Islands Standard Time" = "Pacific/Kiritimati"
+function Load-ApiConfigs {
+    $configPath = Join-Path -Path $PSScriptRoot -ChildPath 'api-configs.json'
+
+    if (-not (Test-Path -LiteralPath $configPath -PathType Leaf)) {
+        Write-Red "Error: API configuration file not found: $configPath"
+        exit 1
+    }
+
+    try {
+        $script:API_CONFIGS = Get-Content -Raw -LiteralPath $configPath -ErrorAction Stop | ConvertFrom-Json -AsHashtable -ErrorAction Stop
+    } catch {
+        Write-Red "Error: Failed to load API configuration file: $($_.Exception.Message)"
+        exit 1
+    }
 }
 
 function Write-Red($msg) {
@@ -790,6 +136,24 @@ function Initialize-EnvironmentVariables {
 function Url-Encode {
     param([string]$text)
     return [System.Uri]::EscapeDataString($text)
+}
+
+function Format-ParamValue {
+    param($Value)
+
+    if ($Value -is [bool]) {
+        return $Value.ToString().ToLower()
+    }
+
+    if ($Value -is [Array]) {
+        return ($Value -join ",")
+    }
+
+    if ($Value -is [Hashtable] -or $Value -is [PSCustomObject]) {
+        return ($Value | ConvertTo-Json -Depth 10 -Compress)
+    }
+
+    return [string]$Value
 }
 
 function Format-Json {
@@ -1134,6 +498,9 @@ function Write-Result {
         "nested_array_to_markdown_table" {
             $dataPath = $prettyConfig.DataPath
             if ($dataPath) {
+                if ($dataPath.StartsWith(".")) {
+                    $dataPath = $dataPath.Substring(1)
+                }
                 $nestedData = $ResultData.$dataPath
             } else {
                 $nestedData = $ResultData
@@ -1167,7 +534,7 @@ function Show-Help {
     Write-Host "A command-line tool for calling ezBookkeeping APIs"
     Write-Host ""
     Write-Host "Usage:"
-    Write-Host "    ebktools.ps1 [-tzName <name>] [-tzOffset <offset>] [-rawResponse] <command> [command-options]"
+    Write-Host "    ebktools.ps1 [-tzName <name>] [-tzOffset <offset>] [-rawResponse] [-dryRun] <command> [command-options]"
     Write-Host ""
     Write-Host "Environment Variables (Required):"
     Write-Host "    EBKTOOL_SERVER_BASEURL      ezBookkeeping server base URL (e.g., http://localhost:8080)"
@@ -1177,8 +544,9 @@ function Show-Help {
     Write-Host ""
     Write-Host "Global Options:"
     Write-Host "    -tzName <name>              The IANA timezone name of current timezone. For example, for Beijing Time it is 'Asia/Shanghai'."
-    Write-Host "    -tzOffset <offset>          The offset in minutes of the current timezone from UTC. For example, for Beijing Time which is UTC+8, the value is '480'. If both '-tzName' and '-tzOffset' are set, '-tzName' takes priority. If neither is set, the current system time zone is used by default."
+    Write-Host "    -tzOffset <offset>          The offset in minutes of the current timezone from UTC. For example, for Beijing Time which is UTC+8, the value is '480'. If both '-tzName' and '-tzOffset' are set, '-tzOffset' takes priority. If neither is set, the current system time zone is used by default."
     Write-Host "    -rawResponse                Display the response in raw JSON format instead of formatted table."
+    Write-Host "    -dryRun                     Print the request method, URL, headers, and JSON body without sending it."
     Write-Host ""
     Write-Host "Commands:"
     Write-Host "    list                        List all available API commands"
@@ -1204,14 +572,19 @@ function Show-Help {
     Write-Host ""
     Write-Host "    # Call API with timezone offset"
     Write-Host "    ebktools.ps1 -tzOffset $exampleTimezoneOffset transactions-list -count 10"
+    Write-Host ""
+    Write-Host "    # Preview a request without sending it"
+    Write-Host "    ebktools.ps1 -dryRun transactions-add -type 3 -categoryId 0 -time 1710000000 -utcOffset 480 -sourceAccountId 1 -sourceAmount -1234"
 }
 
 function Show-CommandList {
     Write-Host "Available API Commands:"
     Write-Host ""
 
+    $nameWidth = (($API_CONFIGS | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum + 2)
+
     foreach ($config in $API_CONFIGS) {
-        $name = $config.Name.PadRight(31)
+        $name = $config.Name.PadRight($nameWidth)
         Write-Host "  $name$($config.Description)"
     }
 
@@ -1293,12 +666,23 @@ function Parse-CommandArgs {
         if ($arg.StartsWith("-")) {
             $paramName = $arg.Substring(1)
 
-            if ($i + 1 -lt $commandArgs.Count -and -not $commandArgs[$i + 1].StartsWith("-")) {
+            if ($i + 1 -lt $commandArgs.Count) {
                 $paramType = "string"
                 $paramValue = $commandArgs[$i + 1]
 
                 if ($paramTypes -and $paramTypes.ContainsKey($paramName)) {
                     $paramType = $paramTypes[$paramName]
+                } elseif ($paramTypes) {
+                    Write-Red "Error: Unknown parameter '-$paramName'"
+                    exit 1
+                }
+
+                if ($paramValue.StartsWith("-")) {
+                    $possibleParamName = $paramValue.Substring(1)
+                    if ($paramTypes -and $paramTypes.ContainsKey($possibleParamName)) {
+                        Write-Red "Error: Parameter '-$paramName' requires a value"
+                        exit 1
+                    }
                 }
 
                 try {
@@ -1309,7 +693,7 @@ function Parse-CommandArgs {
                         }
                         "boolean" {
                             if ($paramValue -match "^(true|false|1|0)$") {
-                                $params[$paramName] = ($paramValue -eq "true" -or $paramValue -eq "1").ToString().ToLower()
+                                $params[$paramName] = ($paramValue -eq "true" -or $paramValue -eq "1")
                             } else {
                                 Write-Red "Error: Parameter '-$paramName' must be a boolean value (true/false or 1/0)"
                                 exit 1
@@ -1335,6 +719,9 @@ function Parse-CommandArgs {
                             }
 
                             $params[$paramName] = $geoLocation
+                        }
+                        "json" {
+                            $params[$paramName] = $paramValue | ConvertFrom-Json -AsHashtable -NoEnumerate
                         }
                         default {
                             $params[$paramName] = $paramValue
@@ -1378,15 +765,23 @@ function Invoke-Api {
     $authToken = $script:EBKTOOL_TOKEN
 
     if (-not $serverBaseUrl) {
-        Write-Red "Error: Environment variable 'EBKTOOL_SERVER_BASEURL' is not set."
-        Write-Host "Please set it to your ezBookkeeping server base URL (e.g., http://localhost:8080)"
-        exit 1
+        if ($script:dryRun) {
+            $serverBaseUrl = "http://example.local"
+        } else {
+            Write-Red "Error: Environment variable 'EBKTOOL_SERVER_BASEURL' is not set."
+            Write-Host "Please set it to your ezBookkeeping server base URL (e.g., http://localhost:8080)"
+            exit 1
+        }
     }
 
     if (-not $authToken) {
-        Write-Red "Error: Environment variable 'EBKTOOL_TOKEN' is not set."
-        Write-Host "Please set it to your API token."
-        exit 1
+        if ($script:dryRun) {
+            $authToken = "DRY_RUN_TOKEN"
+        } else {
+            Write-Red "Error: Environment variable 'EBKTOOL_TOKEN' is not set."
+            Write-Host "Please set it to your API token."
+            exit 1
+        }
     }
 
     $currentTimezoneName = Get-SystemTimezoneName
@@ -1445,25 +840,64 @@ function Invoke-Api {
         if ($config.Method -eq "POST") {
             $headers["Content-Type"] = "application/json"
 
-            Write-Yellow "Calling API: $($config.Method) $url"
+            Write-Yellow "$(if ($script:dryRun) { 'Dry run' } else { 'Calling API' }): $($config.Method) $url"
             Write-Host ""
 
             if ($params.Count -gt 0) {
                 $body = ConvertTo-Json -Depth 10 $params
+                if ($script:dryRun) {
+                    Write-Host "Headers:"
+                    Write-Host "  Authorization: Bearer ***"
+                    Write-Host "  Content-Type: application/json"
+                    if ($headers.ContainsKey("X-Timezone-Name")) {
+                        Write-Host "  X-Timezone-Name: $($headers["X-Timezone-Name"])"
+                    } elseif ($headers.ContainsKey("X-Timezone-Offset")) {
+                        Write-Host "  X-Timezone-Offset: $($headers["X-Timezone-Offset"])"
+                    }
+                    Write-Host ""
+                    Write-Host "Body:"
+                    Write-Host ($body | Format-Json)
+                    return
+                }
                 $response = Invoke-WebRequest -Uri $url -Method POST -Headers $headers -Body $body -ErrorAction Stop -UseBasicParsing
             } else {
+                if ($script:dryRun) {
+                    Write-Host "Headers:"
+                    Write-Host "  Authorization: Bearer ***"
+                    Write-Host "  Content-Type: application/json"
+                    if ($headers.ContainsKey("X-Timezone-Name")) {
+                        Write-Host "  X-Timezone-Name: $($headers["X-Timezone-Name"])"
+                    } elseif ($headers.ContainsKey("X-Timezone-Offset")) {
+                        Write-Host "  X-Timezone-Offset: $($headers["X-Timezone-Offset"])"
+                    }
+                    Write-Host ""
+                    Write-Host "Body:"
+                    Write-Host "{}"
+                    return
+                }
                 $response = Invoke-WebRequest -Uri $url -Method POST -Headers $headers -ErrorAction Stop -UseBasicParsing
             }
 
             $response = ConvertFrom-Json $response.Content
         } else {
             if ($params.Count -gt 0) {
-                $queryString = ($params.GetEnumerator() | ForEach-Object { "$($_.Key)=$(Url-Encode $_.Value)" }) -join "&"
+                $queryString = ($params.GetEnumerator() | ForEach-Object { "$($_.Key)=$(Url-Encode (Format-ParamValue $_.Value))" }) -join "&"
                 $url = "${url}?$queryString"
             }
 
-            Write-Yellow "Calling API: $($config.Method) $url"
+            Write-Yellow "$(if ($script:dryRun) { 'Dry run' } else { 'Calling API' }): $($config.Method) $url"
             Write-Host ""
+
+            if ($script:dryRun) {
+                Write-Host "Headers:"
+                Write-Host "  Authorization: Bearer ***"
+                if ($headers.ContainsKey("X-Timezone-Name")) {
+                    Write-Host "  X-Timezone-Name: $($headers["X-Timezone-Name"])"
+                } elseif ($headers.ContainsKey("X-Timezone-Offset")) {
+                    Write-Host "  X-Timezone-Offset: $($headers["X-Timezone-Offset"])"
+                }
+                return
+            }
 
             $response = Invoke-WebRequest -Uri $url -Method $config.Method -Headers $headers -ErrorAction Stop -UseBasicParsing
             $response = ConvertFrom-Json $response.Content
@@ -1506,6 +940,7 @@ function Invoke-Api {
 }
 
 function Main {
+    Load-ApiConfigs
     Initialize-EnvironmentVariables
 
     if ($Command -eq "list") {

--- a/skills/ezbookkeeping/scripts/ebktools.sh
+++ b/skills/ezbookkeeping/scripts/ebktools.sh
@@ -3,543 +3,15 @@
 # ezBookkeeping API Tools
 # A command-line tool for calling ezBookkeeping APIs
 
-# API Configuration Structure
-API_CONFIGS='[
-    {
-    "Name": "tokens-list",
-    "Description": "Retrieve all sessions for the current user",
-    "Method": "GET",
-    "Path": "tokens/list.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "[",
-      "  {",
-      "    \"tokenId\": \"string (Token ID)\",",
-      "    \"tokenType\": \"integer (Token type, 1: Normal Token, 5: MCP Token, 8: API Token)\",",
-      "    \"userAgent\": \"string (The User Agent when the session created)\",",
-      "    \"lastSeen\": \"integer (Last refresh unix time of the session)\",",
-      "    \"isCurrent\": \"boolean (Whether the session is current)\"",
-      "  }",
-      "]"
-    ],
-    "PrettyResponse": {
-      "Type": "simple_array_to_markdown_table",
-      "Columns": ["tokenId", "tokenType", "userAgent", "lastSeen", "isCurrent"]
-    }
-  },
-  {
-    "Name": "tokens-revoke",
-    "Description": "Revoke a specified token",
-    "Method": "POST",
-    "Path": "tokens/revoke.json",
-    "RequiresTimezone": false,
-    "RequiredParams": ["tokenId"],
-    "OptionalParams": [],
-    "ParamTypes": {
-      "tokenId": "string"
-    },
-    "ParamDescriptions": {
-      "tokenId": "string (Token ID)"
-    },
-    "ResponseStructure": [
-      "boolean (Whether the token is revoked successfully)"
-    ]
-  },
-  {
-    "Name": "accounts-list",
-    "Description": "Retrieve all account information",
-    "Method": "GET",
-    "Path": "accounts/list.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "[",
-      "  {",
-      "    \"id\": \"string (Account ID)\",",
-      "    \"name\": \"string (Account name)\",",
-      "    \"parentId\": \"string (Parent account ID, 0 for primary account)\",",
-      "    \"category\": \"integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)\",",
-      "    \"type\": \"integer (Account type, 1: Single Account, 2: Multiple Sub-accounts)\",",
-      "    \"icon\": \"string (Account icon ID)\",",
-      "    \"color\": \"string (Account icon color, hex color code RRGGBB)\",",
-      "    \"currency\": \"string (Account currency code)\",",
-      "    \"balance\": \"integer (Account balance, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')\",",
-      "    \"comment\": \"string (Account description)\",",
-      "    \"creditCardStatementDate\": \"integer (The statement date of the credit card account)\",",
-      "    \"displayOrder\": \"integer (The display order of the account)\",",
-      "    \"isAsset\": \"boolean (Whether the account is an asset account)\",",
-      "    \"isLiability\": \"boolean (Whether the account is a liability account)\",",
-      "    \"hidden\": \"boolean (Whether the account is hidden)\",",
-      "    \"subAccounts\": [\"each sub-account object like an account object\"]",
-      "  }",
-      "]"
-    ],
-    "PrettyResponse": {
-      "Type": "hierarchical_array_to_markdown_table",
-      "Columns": ["category", "type", "parentId", "id", "name", "currency", "balance", "hidden", "comment"],
-      "ChildKey": "subAccounts"
-    }
-  },
-  {
-    "Name": "accounts-add",
-    "Description": "Add a new account",
-    "Method": "POST",
-    "Path": "accounts/add.json",
-    "RequiresTimezone": true,
-    "RequiredParams": ["name", "category", "type", "icon", "color", "currency"],
-    "OptionalParams": ["balance", "balanceTime", "comment", "creditCardStatementDate"],
-    "ParamTypes": {
-      "name": "string",
-      "category": "integer",
-      "type": "integer",
-      "icon": "string",
-      "color": "string",
-      "currency": "string",
-      "balance": "integer",
-      "balanceTime": "integer",
-      "comment": "string",
-      "creditCardStatementDate": "integer"
-    },
-    "ParamDescriptions": {
-      "name": "string (Account name)",
-      "category": "integer (Account category, 1: Cash, 2: Checking Account, 3: Credit Card, 4: Virtual Account, 5: Debt Account, 6: Receivables, 7: Investment Account, 8: Savings Account, 9: Certificate of Deposit)",
-      "type": "integer (Account type, 1: Single Account, 2: Multiple Sub-accounts)",
-      "icon": "string (Account icon ID)",
-      "color": "string (Account icon color, hex color code RRGGBB)",
-      "currency": "string (Account currency code, ISO 4217 code, '"'"'---'"'"' for the parent account)",
-      "balance": "integer (Account balance, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"'. Liability account should set to negative amount)",
-      "balanceTime": "integer (The unix time when the account balance is the set value. This field is required when balance is set)",
-      "comment": "string (Account description)",
-      "creditCardStatementDate": "integer (The statement date of the credit card account)"
-    },
-    "ResponseStructure": [
-      "{",
-      "  \"id\": \"string (Account ID)\",",
-      "  \"name\": \"string (Account name)\",",
-      "  \"parentId\": \"string (Parent account ID)\",",
-      "  \"category\": \"integer (Account category)\",",
-      "  \"type\": \"integer (Account type)\",",
-      "  \"icon\": \"string (Account icon ID)\",",
-      "  \"color\": \"string (Account icon color)\",",
-      "  \"currency\": \"string (Account currency code)\",",
-      "  \"balance\": \"integer (Account balance)\",",
-      "  \"comment\": \"string (Account description)\",",
-      "  \"creditCardStatementDate\": \"integer (The statement date of the credit card account)\",",
-      "  \"displayOrder\": \"integer (The display order of the account)\",",
-      "  \"isAsset\": \"boolean (Whether the account is an asset account)\",",
-      "  \"isLiability\": \"boolean (Whether the account is a liability account)\",",
-      "  \"hidden\": \"boolean (Whether the account is hidden)\",",
-      "  \"subAccounts\": [\"every sub-account object like account object\"]",
-      "}"
-    ]
-  },
-  {
-    "Name": "transaction-categories-list",
-    "Description": "Retrieve all available transaction categories",
-    "Method": "GET",
-    "Path": "transaction/categories/list.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "{",
-      "  \"transaction category type (1: Income, 2: Expense, 3:Transfer)\": [",
-      "    {",
-      "      \"id\": \"string (Transaction category ID)\",",
-      "      \"name\": \"string (Transaction category name)\",",
-      "      \"parentId\": \"string (Parent transaction category ID, 0 for primary category)\",",
-      "      \"type\": \"integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)\",",
-      "      \"icon\": \"string (Transaction category icon ID)\",",
-      "      \"color\": \"string (Transaction category icon color, hex color code RRGGBB)\",",
-      "      \"comment\": \"string (Transaction category description)\",",
-      "      \"displayOrder\": \"integer (The display order of the transaction category)\",",
-      "      \"hidden\": \"boolean (Whether the transaction category is hidden)\",",
-      "      \"subCategories\": [\"each sub-category object like a transaction category object\"]",
-      "    }",
-      "  ]",
-      "}"
-    ],
-    "PrettyResponse": {
-      "Type": "hierarchical_object_to_markdown_table",
-      "Columns": ["type", "parentId", "id", "name", "hidden", "comment"],
-      "ChildKey": "subCategories"
-    }
-  },
-  {
-    "Name": "transaction-categories-add",
-    "Description": "Add a new transaction category",
-    "Method": "POST",
-    "Path": "transaction/categories/add.json",
-    "RequiresTimezone": false,
-    "RequiredParams": ["name", "type", "icon", "color"],
-    "OptionalParams": ["parentId", "comment"],
-    "ParamTypes": {
-      "name": "string",
-      "type": "integer",
-      "parentId": "string",
-      "icon": "string",
-      "color": "string",
-      "comment": "string"
-    },
-    "ParamDescriptions": {
-      "name": "string (Transaction category name)",
-      "type": "integer (Transaction category type, 1: Income, 2: Expense, 3: Transfer)",
-      "parentId": "string (Parent transaction category ID, 0 for primary category)",
-      "icon": "string (Transaction category icon ID)",
-      "color": "string (Transaction category icon color, hex color code RRGGBB)",
-      "comment": "string (Transaction category description)"
-    },
-    "ResponseStructure": [
-      "{",
-      "  \"id\": \"string (Transaction category ID)\",",
-      "  \"name\": \"string (Transaction category name)\",",
-      "  \"parentId\": \"string (Parent transaction category ID)\",",
-      "  \"type\": \"integer (Transaction category type)\",",
-      "  \"icon\": \"string (Transaction category icon ID)\",",
-      "  \"color\": \"string (Transaction category icon color)\",",
-      "  \"comment\": \"string (Transaction category description)\",",
-      "  \"displayOrder\": \"integer (The display order of the transaction category)\",",
-      "  \"hidden\": \"boolean (Whether the transaction category is hidden)\",",
-      "  \"subCategories\": [\"each sub-category object like a transaction category object\"]",
-      "}"
-    ]
-  },
-  {
-    "Name": "transaction-tags-list",
-    "Description": "Retrieve all available transaction tags",
-    "Method": "GET",
-    "Path": "transaction/tags/list.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "[",
-      "  {",
-      "    \"id\": \"string (Transaction tag ID)\",",
-      "    \"name\": \"string (Transaction tag name)\",",
-      "    \"groupId\": \"string (Transaction tag group ID)\",",
-      "    \"displayOrder\": \"integer (The display order of the transaction tag)\",",
-      "    \"hidden\": \"boolean (Whether the transaction tag is hidden)\"",
-      "  }",
-      "]"
-    ],
-    "PrettyResponse": {
-      "Type": "simple_array_to_markdown_table",
-      "Columns": ["groupId", "id", "name", "hidden"]
-    }
-  },
-  {
-    "Name": "transaction-tags-add",
-    "Description": "Add a new transaction tag",
-    "Method": "POST",
-    "Path": "transaction/tags/add.json",
-    "RequiresTimezone": false,
-    "RequiredParams": ["name"],
-    "OptionalParams": ["groupId"],
-    "ParamTypes": {
-      "name": "string",
-      "groupId": "string"
-    },
-    "ParamDescriptions": {
-      "name": "string (Transaction tag name)",
-      "groupId": "string (Transaction tag group ID, 0 means default group)"
-    },
-    "ResponseStructure": [
-      "{",
-      "  \"id\": \"string (Transaction tag ID)\",",
-      "  \"name\": \"string (Transaction tag name)\",",
-      "  \"groupId\": \"string (Transaction tag group ID)\",",
-      "  \"displayOrder\": \"integer (The display order of the transaction tag)\",",
-      "  \"hidden\": \"boolean (Whether the transaction tag is hidden)\"",
-      "}"
-    ]
-  },
-  {
-    "Name": "transactions-list",
-    "Description": "Retrieve transaction data based on specified query criteria (with pagination support)",
-    "Method": "GET",
-    "Path": "transactions/list.json",
-    "RequiresTimezone": true,
-    "RequiredParams": ["count"],
-    "OptionalParams": ["type", "category_ids", "account_ids", "tag_filter", "amount_filter", "keyword", "must_have_pictures", "max_time", "min_time", "page", "with_count", "with_pictures", "trim_account", "trim_category", "trim_tag"],
-    "ParamTypes": {
-      "count": "integer",
-      "type": "integer",
-      "category_ids": "string",
-      "account_ids": "string",
-      "tag_filter": "string",
-      "amount_filter": "string",
-      "keyword": "string",
-      "must_have_pictures": "boolean",
-      "max_time": "integer",
-      "min_time": "integer",
-      "page": "integer",
-      "with_count": "boolean",
-      "with_pictures": "boolean",
-      "trim_account": "boolean",
-      "trim_category": "boolean",
-      "trim_tag": "boolean"
-    },
-    "ParamDescriptions": {
-      "count": "integer (The count of transactions per page, maximum is 50)",
-      "type": "integer (Filter transaction by type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
-      "category_ids": "string (Filter by category IDs, separated by comma)",
-      "account_ids": "string (Filter by account IDs, separated by comma)",
-      "tag_filter": "string (Filter by tags)",
-      "amount_filter": "string (Filter by amount)",
-      "keyword": "string (Filter by keyword)",
-      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
-      "max_time": "integer (The maximum time sequence ID, Set to 0 for latest)",
-      "min_time": "integer (The minimum time sequence ID)",
-      "page": "integer (Specified page integer)",
-      "with_count": "boolean (Whether to get total count)",
-      "with_pictures": "boolean (Whether to get picture IDs)",
-      "trim_account": "boolean (Whether to get account ID only)",
-      "trim_category": "boolean (Whether to get category ID only)",
-      "trim_tag": "boolean (Whether to get tag IDs only)"
-    },
-    "ResponseStructure": [
-      "{",
-      "  \"items\": [",
-      "    {",
-      "      \"id\": \"string (Transaction ID)\",",
-      "      \"timeSequenceId\": \"string (Transaction time sequence ID)\",",
-      "      \"type\": \"integer (Transaction type)\",",
-      "      \"categoryId\": \"string (Transaction category ID)\",",
-      "      \"category\": \"object (Transaction category object)\",",
-      "      \"time\": \"integer (Transaction unix time)\",",
-      "      \"utcOffset\": \"integer (Transaction time zone offset minutes)\",",
-      "      \"sourceAccountId\": \"string (Source account ID)\",",
-      "      \"sourceAccount\": \"object (Source account object)\",",
-      "      \"destinationAccountId\": \"string (Destination account ID)\",",
-      "      \"destinationAccount\": \"object (Destination account object)\",",
-      "      \"sourceAmount\": \"integer (Source amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')\",",
-      "      \"destinationAmount\": \"integer (Destination amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')\",",
-      "      \"hideAmount\": \"boolean (Whether to hide the amount)\",",
-      "      \"tagIds\": [\"each string representing a transaction tag ID\"],",
-      "      \"tags\": [\"each object representing a transaction tag object\"],",
-      "      \"pictures\": [\"each object representing a transaction picture object\"],",
-      "      \"comment\": \"string (Transaction description)\",",
-      "      \"geoLocation\": \"object (Transaction geographic location)\",",
-      "      \"editable\": \"boolean (Whether the transaction is editable)\"",
-      "    }",
-      "  ],",
-      "  \"nextTimeSequenceId\": \"integer (The next cursor '"'"'max_time'"'"' parameter when requesting older data)\",",
-      "  \"totalCount\": \"integer (The total count of transactions)\"",
-      "}"
-    ],
-    "PrettyResponse": {
-      "Type": "nested_array_to_markdown_table",
-      "Columns": ["id", "type", "time", "utcOffset", "categoryId", "sourceAccountId", "sourceAmount", "destinationAccountId", "destinationAmount", "tagIds", "geoLocation", "comment"],
-      "DataPath": ".items",
-      "Metadata": [
-        {"Field": "totalCount", "Label": "Total Count"},
-        {"Field": "nextTimeSequenceId", "Label": "Next Time Sequence ID"}
-      ]
-    }
-  },
-  {
-    "Name": "transactions-list-all",
-    "Description": "Retrieve all transaction data matching the specified query criteria",
-    "Method": "GET",
-    "Path": "transactions/list/all.json",
-    "RequiresTimezone": true,
-    "RequiredParams": [],
-    "OptionalParams": ["type", "category_ids", "account_ids", "tag_filter", "amount_filter", "keyword", "must_have_pictures", "start_time", "end_time", "with_pictures", "trim_account", "trim_category", "trim_tag"],
-    "ParamTypes": {
-      "type": "integer",
-      "category_ids": "string",
-      "account_ids": "string",
-      "tag_filter": "string",
-      "amount_filter": "string",
-      "keyword": "string",
-      "must_have_pictures": "boolean",
-      "start_time": "integer",
-      "end_time": "integer",
-      "with_pictures": "boolean",
-      "trim_account": "boolean",
-      "trim_category": "boolean",
-      "trim_tag": "boolean"
-    },
-    "ParamDescriptions": {
-      "type": "integer (Filter transaction by type, 1: Balance modification, 2: Income, 3: Expense, 4: Transfer)",
-      "category_ids": "string (Filter by category IDs, separated by comma)",
-      "account_ids": "string (Filter by account IDs, separated by comma)",
-      "tag_filter": "string (Filter by tags)",
-      "amount_filter": "string (Filter by amount)",
-      "keyword": "string (Filter by keyword)",
-      "must_have_pictures": "boolean (Whether to only get transactions with pictures)",
-      "start_time": "integer (Transaction list start unix time)",
-      "end_time": "integer (Transaction list end unix time)",
-      "with_pictures": "boolean (Whether to get picture IDs)",
-      "trim_account": "boolean (Whether to get account ID only)",
-      "trim_category": "boolean (Whether to get category ID only)",
-      "trim_tag": "boolean (Whether to get tag IDs only)"
-    },
-    "ResponseStructure": [
-      "[",
-      "  {",
-      "    \"id\": \"string (Transaction ID)\",",
-      "    \"timeSequenceId\": \"string (Transaction time sequence ID)\",",
-      "    \"type\": \"integer (Transaction type)\",",
-      "    \"categoryId\": \"string (Transaction category ID)\",",
-      "    \"category\": \"object (Transaction category object)\",",
-      "    \"time\": \"integer (Transaction unix time)\",",
-      "    \"utcOffset\": \"integer (Transaction time zone offset minutes)\",",
-      "    \"sourceAccountId\": \"string (Source account ID)\",",
-      "    \"sourceAccount\": \"object (Source account object)\",",
-      "    \"destinationAccountId\": \"string (Destination account ID)\",",
-      "    \"destinationAccount\": \"object (Destination account object)\",",
-      "    \"sourceAmount\": \"integer (Source amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')\",",
-      "    \"destinationAmount\": \"integer (Destination amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')\",",
-      "    \"hideAmount\": \"boolean (Whether to hide the amount)\",",
-      "    \"tagIds\": [\"each string representing a transaction tag ID\"],",
-      "    \"tags\": [\"each object representing a transaction tag object\"],",
-      "    \"pictures\": [\"each object representing a transaction picture object\"],",
-      "    \"comment\": \"string (Transaction description)\",",
-      "    \"geoLocation\": \"object (Transaction geographic location)\",",
-      "    \"editable\": \"boolean (Whether the transaction is editable)\"",
-      "  }",
-      "]"
-    ],
-    "PrettyResponse": {
-      "Type": "simple_array_to_markdown_table",
-      "Columns": ["id", "type", "time", "utcOffset", "categoryId", "sourceAccountId", "sourceAmount", "destinationAccountId", "destinationAmount", "tagIds", "geoLocation", "comment"]
-    }
-  },
-  {
-    "Name": "transactions-add",
-    "Description": "Add a new transaction",
-    "Method": "POST",
-    "Path": "transactions/add.json",
-    "RequiresTimezone": true,
-    "RequiredParams": ["type", "categoryId", "time", "utcOffset", "sourceAccountId", "sourceAmount"],
-    "OptionalParams": ["destinationAccountId", "destinationAmount", "hideAmount", "tagIds", "pictureIds", "comment", "geoLocation"],
-    "ParamTypes": {
-      "type": "integer",
-      "categoryId": "string",
-      "time": "integer",
-      "utcOffset": "integer",
-      "sourceAccountId": "string",
-      "sourceAmount": "integer",
-      "destinationAccountId": "string",
-      "destinationAmount": "integer",
-      "hideAmount": "boolean",
-      "tagIds": "string_array",
-      "pictureIds": "string_array",
-      "comment": "string",
-      "geoLocation": "geo_location"
-    },
-    "ParamDescriptions": {
-      "type": "integer (Transaction type, 1: Balance Modification, 2: Income, 3: Expense, 4: Transfer)",
-      "categoryId": "string (Transaction category ID, supports secondary category)",
-      "time": "integer (Transaction unix time)",
-      "utcOffset": "integer (Transaction time zone offset minutes)",
-      "sourceAccountId": "string (Source account ID, supports account without sub-accounts or sub-account)",
-      "sourceAmount": "integer (Source amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')",
-      "destinationAccountId": "string (Destination account ID, supports account without sub-accounts or sub-account)",
-      "destinationAmount": "integer (Destination amount, supports up to two decimals. For example, a value of '"'"'1234'"'"' represents an amount of '"'"'12.34'"'"')",
-      "hideAmount": "boolean (Whether to hide amount)",
-      "tagIds": "string (Transaction tag IDs, separated by comma, e.g. '"'"'tagid1,tagid2'"'"')",
-      "pictureIds": "string (Transaction picture IDs, separated by comma, e.g. '"'"'picid1,picid2'"'"')",
-      "comment": "string (Transaction description)",
-      "geoLocation": "string (Transaction geographic location, format: longitude,latitude, e.g. '"'"'116.33,39.93'"'"')"
-    },
-    "ResponseStructure": [
-      "{",
-      "  \"id\": \"string (Transaction ID)\",",
-      "  \"timeSequenceId\": \"string (Transaction time sequence ID)\",",
-      "  \"type\": \"integer (Transaction type)\",",
-      "  \"categoryId\": \"string (Transaction category ID)\",",
-      "  \"category\": \"object (Transaction category object)\",",
-      "  \"time\": \"integer (Transaction unix time)\",",
-      "  \"utcOffset\": \"integer (Transaction time zone offset minutes)\",",
-      "  \"sourceAccountId\": \"string (Source account ID)\",",
-      "  \"sourceAccount\": \"object (Source account object)\",",
-      "  \"destinationAccountId\": \"string (Destination account ID)\",",
-      "  \"destinationAccount\": \"object (Destination account object)\",",
-      "  \"sourceAmount\": \"integer (Source amount)\",",
-      "  \"destinationAmount\": \"integer (Destination amount)\",",
-      "  \"hideAmount\": \"boolean (Whether to hide the amount)\",",
-      "  \"tagIds\": [\"each string representing a transaction tag ID\"],",
-      "  \"tags\": [\"each object representing a transaction tag object\"],",
-      "  \"pictures\": [\"each object representing a transaction picture object\"],",
-      "  \"comment\": \"string (Transaction description)\",",
-      "  \"geoLocation\": \"object (Transaction geographic location)\",",
-      "  \"editable\": \"boolean (Whether the transaction is editable)\"",
-      "}"
-    ]
-  },
-  {
-    "Name": "exchangerates-latest",
-    "Description": "Retrieve the latest exchange rate data",
-    "Method": "GET",
-    "Path": "exchange_rates/latest.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "{",
-      "  \"dataSource\": \"string (Exchange rate data source name)\",",
-      "  \"referenceUrl\": \"string (Exchange rate data reference URL)\",",
-      "  \"updateTime\": \"integer (Exchange rate data update unix time)\",",
-      "  \"baseCurrency\": \"string (Base currency code)\",",
-      "  \"exchangeRates\": [",
-      "    {",
-      "      \"currency\": \"string (Currency code)\",",
-      "      \"rate\": \"string (Exchange rate, 1 unit of base currency equals to how many units of this currency)\"",
-      "    }",
-      "  ]",
-      "}"
-    ],
-    "PrettyResponse": {
-      "Type": "nested_array_to_markdown_table",
-      "Columns": ["currency", "rate"],
-      "DataPath": ".exchangeRates",
-      "Metadata": [
-        {"Field": "dataSource", "Label": "Data Source"},
-        {"Field": "baseCurrency", "Label": "Base Currency"},
-        {"Field": "updateTime", "Label": "Update Time"}
-      ]
-    }
-  },
-  {
-    "Name": "server-version",
-    "Description": "Retrieve ezBookkeeping server version information",
-    "Method": "GET",
-    "Path": "systems/version.json",
-    "RequiresTimezone": false,
-    "RequiredParams": [],
-    "OptionalParams": [],
-    "ParamTypes": {},
-    "ParamDescriptions": {},
-    "ResponseStructure": [
-      "{",
-      "  \"version\": \"string (Server version)\",",
-      "  \"commitHash\": \"string (Git commit hash)\"",
-      "}"
-    ]
-  }
-]'
+SCRIPT_DIR=$(CDPATH= cd "$(dirname "$0")" && pwd)
+API_CONFIGS=""
 
 EBKTOOL_SERVER_BASEURL="${EBKTOOL_SERVER_BASEURL}"
 EBKTOOL_TOKEN="${EBKTOOL_TOKEN}"
 TIMEZONE_NAME=""
 TIMEZONE_OFFSET=""
 RAW_RESPONSE="false"
+DRY_RUN="false"
 
 echo_red() {
     printf '\033[31m%s\033[0m\n' "$1"
@@ -557,6 +29,20 @@ check_dependency() {
             exit 127
         fi
     done
+}
+
+load_api_configs() {
+    config_file="$SCRIPT_DIR/api-configs.json"
+
+    if [ ! -f "$config_file" ]; then
+        echo_red "Error: API configuration file not found: $config_file"
+        exit 1
+    fi
+
+    if ! API_CONFIGS="$(jq -c '.' "$config_file" 2>/dev/null)"; then
+        echo_red "Error: Failed to load API configuration file: $config_file"
+        exit 1
+    fi
 }
 
 load_env_file() {
@@ -789,6 +275,10 @@ print_result() {
             ;;
         nested_array_to_markdown_table)
             data_path="$(echo "$pretty_config" | jq -r '.DataPath // "."')"
+            case "$data_path" in
+                .*) ;;
+                *) data_path=".$data_path" ;;
+            esac
             nested_data="$(printf "%s\n" "$result_data" | jq -r "$data_path")"
 
             metadata="$(echo "$pretty_config" | jq -r '.Metadata // null')"
@@ -818,7 +308,7 @@ ezBookkeeping API Tools
 A command-line tool for calling ezBookkeeping APIs
 
 Usage:
-    ebktools.sh [--tz-name <name>] [--tz-offset <offset>] [--raw-response] <command> [command-options]
+    ebktools.sh [--tz-name <name>] [--tz-offset <offset>] [--raw-response] [--dry-run] <command> [command-options]
 
 Environment Variables (Required):
     EBKTOOL_SERVER_BASEURL      ezBookkeeping server base URL (e.g., http://localhost:8080)
@@ -828,8 +318,9 @@ Environment Variables (Required):
 
 Global Options:
     --tz-name <name>            The IANA timezone name of current timezone. For example, for Beijing Time it is 'Asia/Shanghai'.
-    --tz-offset <offset>        The offset in minutes of the current timezone from UTC. For example, for Beijing Time which is UTC+8, the value is '480'. If both '--tz-name' and '--tz-offset' are set, '--tz-name' takes priority. If neither is set, the current system time zone is used by default.
+    --tz-offset <offset>        The offset in minutes of the current timezone from UTC. For example, for Beijing Time which is UTC+8, the value is '480'. If both '--tz-name' and '--tz-offset' are set, '--tz-offset' takes priority. If neither is set, the current system time zone is used by default.
     --raw-response              Display the response in raw JSON format instead of formatted table.
+    --dry-run                   Print the request method, URL, headers, and JSON body without sending it.
 
 Commands:
     list                        List all available API commands
@@ -855,6 +346,9 @@ Examples:
 
     # Call API with timezone offset
     ebktools.sh --tz-offset ${example_timezone_offset} transactions-list --count 10
+
+    # Preview a request without sending it
+    ebktools.sh --dry-run transactions-add --type 3 --categoryId 0 --time 1710000000 --utcOffset 480 --sourceAccountId 1 --sourceAmount -1234
 EOF
 }
 
@@ -862,8 +356,10 @@ list_commands() {
     echo "Available API Commands:"
     echo ""
 
+    name_width="$(echo "$API_CONFIGS" | jq '[.[].Name | length] | max + 2')"
+
     echo "$API_CONFIGS" | jq -r '.[] | "\(.Name)|\(.Description)"' | while IFS='|' read -r name desc; do
-        printf "  %-30s %s\n" "$name" "$desc"
+        printf "  %-*s %s\n" "$name_width" "$name" "$desc"
     done
 
     echo ""
@@ -956,15 +452,23 @@ call_api() {
     authToken="$EBKTOOL_TOKEN"
 
     if [ -z "$serverBaseUrl" ]; then
-        echo_red "Error: Environment variable 'EBKTOOL_SERVER_BASEURL' is not set."
-        echo "Please set it to your ezBookkeeping server base URL (e.g., http://localhost:8080)"
-        exit 1
+        if [ "$DRY_RUN" = "true" ]; then
+            serverBaseUrl="http://example.local"
+        else
+            echo_red "Error: Environment variable 'EBKTOOL_SERVER_BASEURL' is not set."
+            echo "Please set it to your ezBookkeeping server base URL (e.g., http://localhost:8080)"
+            exit 1
+        fi
     fi
 
     if [ -z "$authToken" ]; then
-        echo_red "Error: Environment variable 'EBKTOOL_TOKEN' is not set."
-        echo "Please set it to your API token."
-        exit 1
+        if [ "$DRY_RUN" = "true" ]; then
+            authToken="DRY_RUN_TOKEN"
+        else
+            echo_red "Error: Environment variable 'EBKTOOL_TOKEN' is not set."
+            echo "Please set it to your API token."
+            exit 1
+        fi
     fi
 
     requires_timezone="$(echo "$config" | jq -r '.RequiresTimezone // false')"
@@ -999,6 +503,11 @@ call_api() {
         echo "$param_type"
     }
 
+    has_param_type() {
+        param_name="$1"
+        echo "$config" | jq -e --arg p "$param_name" '.ParamTypes | has($p)' >/dev/null 2>&1
+    }
+
     validate_param() {
         param_name="$1"
         param_value="$2"
@@ -1023,11 +532,18 @@ call_api() {
                     exit 1
                 fi
                 ;;
+            json)
+                if ! printf "%s\n" "$param_value" | jq -e '.' >/dev/null 2>&1; then
+                    echo_red "Error: Parameter '--${param_name}' must be valid JSON"
+                    exit 1
+                fi
+                ;;
         esac
     }
 
     params=""
     json_params="{}"
+    present_params="|"
     while [ $# -gt 0 ]; do
         case "${1}" in
             --*)
@@ -1038,15 +554,18 @@ call_api() {
                     exit 1
                 fi
 
-                case "$2" in
-                    --*)
-                        echo_red "Error: Parameter '--${param_name}' requires a value"
-                        exit 1
-                        ;;
-                esac
-
                 param_value="$2"
-                param_type="$(get_param_type "$param_name")"
+                if has_param_type "$param_name"; then
+                    param_type="$(get_param_type "$param_name")"
+                else
+                    echo_red "Error: Unknown parameter '--${param_name}'"
+                    exit 1
+                fi
+
+                if [ "${param_value#--}" != "$param_value" ]; then
+                    echo_red "Error: Parameter '--${param_name}' requires a value"
+                    exit 1
+                fi
 
                 validate_param "$param_name" "$param_value" "$param_type"
 
@@ -1056,6 +575,7 @@ call_api() {
                 else
                     params="${params}&${param_name}=${encoded_value}"
                 fi
+                present_params="${present_params}${param_name}|"
 
                 case "$param_type" in
                     integer)
@@ -1085,6 +605,9 @@ call_api() {
                         geo_json="$(jq -n --arg lat "$latitude" --arg lon "$longitude" '{latitude: ($lat | tonumber), longitude: ($lon | tonumber)}')"
                         json_params="$(echo "$json_params" | jq --arg k "$param_name" --argjson v "$geo_json" '. + {($k): $v}')"
                         ;;
+                    json)
+                        json_params="$(echo "$json_params" | jq --arg k "$param_name" --argjson v "$param_value" '. + {($k): $v}')"
+                        ;;
                     *)
                         json_params="$(echo "$json_params" | jq --arg k "$param_name" --arg v "$param_value" '. + {($k): $v}')"
                         ;;
@@ -1103,10 +626,13 @@ call_api() {
         i=0
         while [ "$i" -lt "$required_count" ]; do
             param="$(echo "$config" | jq -r --argjson idx "$i" '.RequiredParams[$idx]')"
-            if ! echo "$params" | grep -q "${param}="; then
-                echo_red "Error: Required parameter '--${param}' is missing"
-                exit 1
-            fi
+            case "$present_params" in
+                *"|${param}|"*) ;;
+                *)
+                    echo_red "Error: Required parameter '--${param}' is missing"
+                    exit 1
+                    ;;
+            esac
             i=$((i + 1))
         done
     fi
@@ -1125,8 +651,25 @@ call_api() {
     fi
 
     if [ "$method" = "POST" ]; then
-        echo_yellow "Calling API: $method $url"
+        if [ "$DRY_RUN" = "true" ]; then
+            echo_yellow "Dry run: $method $url"
+        else
+            echo_yellow "Calling API: $method $url"
+        fi
         echo ""
+
+        if [ "$DRY_RUN" = "true" ]; then
+            echo "Headers:"
+            echo "  Authorization: Bearer ***"
+            echo "  Content-Type: application/json"
+            if [ -n "$timezone_headers" ]; then
+                echo "  $timezone_headers"
+            fi
+            echo ""
+            echo "Body:"
+            printf "%s\n" "$json_params" | jq '.'
+            return
+        fi
 
         if [ "$json_params" != "{}" ]; then
             if [ -n "$timezone_headers" ]; then
@@ -1164,8 +707,21 @@ call_api() {
             url="${url}?${params}"
         fi
 
-        echo_yellow "Calling API: $method $url"
+        if [ "$DRY_RUN" = "true" ]; then
+            echo_yellow "Dry run: $method $url"
+        else
+            echo_yellow "Calling API: $method $url"
+        fi
         echo ""
+
+        if [ "$DRY_RUN" = "true" ]; then
+            echo "Headers:"
+            echo "  Authorization: Bearer ***"
+            if [ -n "$timezone_headers" ]; then
+                echo "  $timezone_headers"
+            fi
+            return
+        fi
 
         if [ -n "$timezone_headers" ]; then
             response="$(curl -s -X "$method" \
@@ -1206,6 +762,7 @@ call_api() {
 
 main() {
     check_dependency "grep sed awk date curl jq"
+    load_api_configs
 
     load_env_from_paths
 
@@ -1231,6 +788,10 @@ main() {
                 ;;
             --raw-response)
                 RAW_RESPONSE="true"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN="true"
                 shift
                 ;;
             --help | -h)


### PR DESCRIPTION
## Summary

- Expand ezBookkeeping skill coverage for accounts, transaction categories, tag groups, tags, transactions, exchange rates, sessions, and server version APIs.
- Move shared command definitions into `scripts/api-configs.json` so the PowerShell and POSIX shell tools use the same API metadata.
- Add dry-run support for safer destructive and batch operations.
- Improve parameter parsing for booleans, negative numeric values, string arrays, geo locations, and JSON object/array parameters.
- Keep the skill concise and agent-agnostic while documenting common safe workflows.

## Validation

- Ran skill validation successfully: `quick_validate.py skills/ezbookkeeping`.
- Ran `git diff --check -- skills/ezbookkeeping`.
- Verified all 52 configured API commands map to registered `/api/v1` routes in `cmd/webserver.go`.
- Verified PowerShell dry-run scenarios for transaction creation, account move, batch category creation, batch transaction deletion, GET query params, invalid numeric values, unknown parameters, and timezone precedence.
- Installed `jq` in WSL and verified POSIX shell scenarios for `list`, `help`, transaction creation, account move, batch category creation, batch transaction deletion, GET query params, invalid numeric values, and unknown parameters.