### PR TITLE
fix(utils): correct sign for sub-hour negative timezone offsets

### DIFF
--- a/pkg/utils/datetimes.go
+++ b/pkg/utils/datetimes.go
@@ -313,14 +313,14 @@ func FormatTimezoneOffset(unixTime int64, timezone *time.Location) string {
 	tzMinutesOffset := GetTimezoneOffsetMinutes(unixTime, timezone)
 
 	sign := "+"
+
+	if tzMinutesOffset < 0 {
+		sign = "-"
+		tzMinutesOffset = -tzMinutesOffset
+	}
+
 	hourAbsOffset := tzMinutesOffset / 60
 	minuteAbsOffset := tzMinutesOffset % 60
-
-	if hourAbsOffset < 0 {
-		sign = "-"
-		hourAbsOffset = -hourAbsOffset
-		minuteAbsOffset = -minuteAbsOffset
-	}
 
 	return fmt.Sprintf("%s%02d:%02d", sign, hourAbsOffset, minuteAbsOffset)
 }
@@ -336,14 +336,14 @@ func FormatTimezoneOffsetFromHoursOffset(hoursOffset string) (string, error) {
 	tzMinutesOffset := int16(hoursOffsetValue * 60)
 
 	sign := "+"
+
+	if tzMinutesOffset < 0 {
+		sign = "-"
+		tzMinutesOffset = -tzMinutesOffset
+	}
+
 	hourAbsOffset := tzMinutesOffset / 60
 	minuteAbsOffset := tzMinutesOffset % 60
-
-	if hourAbsOffset < 0 {
-		sign = "-"
-		hourAbsOffset = -hourAbsOffset
-		minuteAbsOffset = -minuteAbsOffset
-	}
 
 	return fmt.Sprintf("%s%02d:%02d", sign, hourAbsOffset, minuteAbsOffset), nil
 }

--- a/pkg/utils/datetimes_test.go
+++ b/pkg/utils/datetimes_test.go
@@ -421,6 +421,11 @@ func TestFormatTimezoneOffset_FixedTimezone(t *testing.T) {
 	expectedValue = "+00:00"
 	actualValue = FormatTimezoneOffset(time.Now().Unix(), timezone)
 	assert.Equal(t, expectedValue, actualValue)
+
+	timezone = time.FixedZone("Test Timezone", -30*60)
+	expectedValue = "-00:30"
+	actualValue = FormatTimezoneOffset(time.Now().Unix(), timezone)
+	assert.Equal(t, expectedValue, actualValue)
 }
 
 func TestFormatTimezoneOffset_TimezoneWithDST(t *testing.T) {
@@ -461,6 +466,11 @@ func TestFormatTimezoneOffsetFromHoursOffset(t *testing.T) {
 
 	expectedValue = "+00:00"
 	actualValue, err = FormatTimezoneOffsetFromHoursOffset("0")
+	assert.Nil(t, err)
+	assert.Equal(t, expectedValue, actualValue)
+
+	expectedValue = "-00:30"
+	actualValue, err = FormatTimezoneOffsetFromHoursOffset("-0.5")
 	assert.Nil(t, err)
 	assert.Equal(t, expectedValue, actualValue)
 }


### PR DESCRIPTION
## Summary

`FormatTimezoneOffset` and `FormatTimezoneOffsetFromHoursOffset` (in `pkg/utils/datetimes.go`) format a timezone offset as `+/-HH:MM`. They chose the output sign from the **hour** component (`hourAbsOffset < 0`).

For a negative offset whose hour component is exactly `0` — i.e. an offset in the open range `(-60, 0)` minutes — integer division gives `hourAbsOffset == 0` (not `< 0`), so the negative branch is skipped. The minute is never negated and the result prints a positive sign with a negative minute:

| input | expected | actual (before) |
|-------|----------|-----------------|
| `time.FixedZone("", -30*60)` | `-00:30` | `+00:-30` |
| `FormatTimezoneOffsetFromHoursOffset("-0.5")` | `-00:30` | `+00:-30` |

### Impact
- The malformed string (`+00:-30`, length 7) also fails to round-trip through `ParseFromTimezoneOffset`, which requires a length of 6.
- `FormatTimezoneOffsetFromHoursOffset` is reached from the OFX import path (`pkg/converters/ofx/ofx_transaction_data_table.go`), where the GMT offset comes from a user-supplied file, so a fractional negative offset such as `-0:30` corrupts the imported transaction's timezone.

Whole-hour negative offsets (e.g. `-12:00`, `-02:30`) were unaffected and stay correct.

## Fix

Derive the sign from the **total** signed offset and take its absolute value before splitting into hour/minute components, so the sign is applied once to the whole offset. The change is applied consistently to both functions.

## Test Plan

Added regression cases for sub-hour negative offsets to the existing table tests in `pkg/utils/datetimes_test.go` (`TestFormatTimezoneOffset_FixedTimezone` and `TestFormatTimezoneOffsetFromHoursOffset`).

Fails before the fix:
```
--- FAIL: TestFormatTimezoneOffset_FixedTimezone
    expected: "-00:30"  actual: "+00:-30"
--- FAIL: TestFormatTimezoneOffsetFromHoursOffset
    expected: "-00:30"  actual: "+00:-30"
```

Passes after the fix:
```
ok  github.com/mayswind/ezbookkeeping/pkg/utils   0.225s   (full package)
ok  github.com/mayswind/ezbookkeeping/pkg/converters/ofx   0.438s
```
`gofmt -l` clean, `go vet ./pkg/utils/` clean, `go build ./...` succeeds.

---
*Prepared with AI assistance (Claude Code); the change was reviewed, built, and tested by a human before submitting.*
