### PR TITLE
feat: support creating nonexistent accounts and hierarchical categories when importing transactions

### DIFF
--- a/pkg/converters/converter/data_table_transaction_data_importer.go
+++ b/pkg/converters/converter/data_table_transaction_data_importer.go
@@ -386,6 +386,7 @@ func (c *DataTableTransactionDataImporter) ParseImportedData(ctx core.Context, u
 				CreatedIp:            ctx.ClientIP(),
 			},
 			TagIds:                             tagIds,
+			OriginalPrimaryCategoryName:        categoryName,
 			OriginalCategoryName:               subCategoryName,
 			OriginalSourceAccountName:          accountName,
 			OriginalSourceAccountCurrency:      accountCurrency,

--- a/pkg/models/imported_transaction.go
+++ b/pkg/models/imported_transaction.go
@@ -6,6 +6,7 @@ import "github.com/mayswind/ezbookkeeping/pkg/utils"
 type ImportTransaction struct {
 	*Transaction
 	TagIds                             []string
+	OriginalPrimaryCategoryName        string
 	OriginalCategoryName               string
 	OriginalSourceAccountName          string
 	OriginalSourceAccountCurrency      string
@@ -38,6 +39,7 @@ type ImportTransactionRequestItem struct {
 type ImportTransactionResponse struct {
 	Type                               TransactionType                 `json:"type"`
 	CategoryId                         int64                           `json:"categoryId,string"`
+	OriginalPrimaryCategoryName        string                          `json:"originalPrimaryCategoryName"`
 	OriginalCategoryName               string                          `json:"originalCategoryName"`
 	Time                               int64                           `json:"time"`
 	UtcOffset                          int16                           `json:"utcOffset"`
@@ -81,6 +83,7 @@ func (t ImportTransaction) ToImportTransactionResponse() *ImportTransactionRespo
 	return &ImportTransactionResponse{
 		Type:                               transactionType,
 		CategoryId:                         t.CategoryId,
+		OriginalPrimaryCategoryName:        t.OriginalPrimaryCategoryName,
 		OriginalCategoryName:               t.OriginalCategoryName,
 		Time:                               utils.GetUnixTimeFromTransactionTime(t.TransactionTime),
 		UtcOffset:                          t.TimezoneUtcOffset,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -2189,6 +2189,7 @@
     "Create Nonexistent Expense Categories": "Create Nonexistent Expense Categories",
     "Create Nonexistent Income Categories": "Create Nonexistent Income Categories",
     "Create Nonexistent Transfer Categories": "Create Nonexistent Transfer Categories",
+    "Create Nonexistent Accounts": "Create Nonexistent Accounts",
     "Create Nonexistent Transaction Tags": "Create Nonexistent Transaction Tags",
     "Batch Convert Expense Transaction to Income Transaction": "Batch Convert Expense Transaction to Income Transaction",
     "Batch Convert Expense Transaction to Transfer Transaction": "Batch Convert Expense Transaction to Transfer Transaction",

--- a/src/locales/zh_Hans.json
+++ b/src/locales/zh_Hans.json
@@ -2189,6 +2189,7 @@
     "Create Nonexistent Expense Categories": "创建不存在的支出分类",
     "Create Nonexistent Income Categories": "创建不存在的收入分类",
     "Create Nonexistent Transfer Categories": "创建不存在的转账分类",
+    "Create Nonexistent Accounts": "创建不存在的账户",
     "Create Nonexistent Transaction Tags": "创建不存在的交易标签",
     "Batch Convert Expense Transaction to Income Transaction": "批量转换支出交易为收入交易",
     "Batch Convert Expense Transaction to Transfer Transaction": "批量转换支出交易为转账交易",

--- a/src/locales/zh_Hant.json
+++ b/src/locales/zh_Hant.json
@@ -2189,6 +2189,7 @@
     "Create Nonexistent Expense Categories": "建立不存在的支出分類",
     "Create Nonexistent Income Categories": "建立不存在的收入分類",
     "Create Nonexistent Transfer Categories": "建立不存在的轉帳分類",
+    "Create Nonexistent Accounts": "建立不存在的帳戶",
     "Create Nonexistent Transaction Tags": "建立不存在的交易標籤",
     "Batch Convert Expense Transaction to Income Transaction": "批次將支出交易轉換為收入交易",
     "Batch Convert Expense Transaction to Transfer Transaction": "批次將支出交易轉換為轉帳交易",

--- a/src/models/imported_transaction.ts
+++ b/src/models/imported_transaction.ts
@@ -2,9 +2,58 @@ import { TransactionType } from '@/core/transaction.ts';
 
 import type { TransactionCreateRequest, TransactionGeoLocationResponse } from './transaction.ts';
 
+// 组合键分隔符：用于在批量创建对话框中唯一标识“一级分类名 + 二级分类名”或“账户名 + 币种”。
+// 选用单元分隔符 U+001F（ASCII 0x1F），它不会出现在用户填写的分类名 / 账户名 / 币种中，可避免歧义与碰撞。
+const IMPORT_COMPOSITE_KEY_SEPARATOR = '\u001f';
+
+// 构造"一级分类名 + 二级分类名"的组合键
+// primaryCategoryName: 一级分类名（可能为空字符串）
+// subCategoryName: 二级分类名
+export function getImportCategoryCompositeKey(primaryCategoryName: string, subCategoryName: string): string {
+    return `${primaryCategoryName}${IMPORT_COMPOSITE_KEY_SEPARATOR}${subCategoryName}`;
+}
+
+// 解析"一级分类名 + 二级分类名"的组合键
+// key: 由 getImportCategoryCompositeKey 生成的组合键
+export function parseImportCategoryCompositeKey(key: string): { primaryCategoryName: string, subCategoryName: string } {
+    const separatorIndex = key.indexOf(IMPORT_COMPOSITE_KEY_SEPARATOR);
+
+    if (separatorIndex < 0) {
+        return { primaryCategoryName: '', subCategoryName: key };
+    }
+
+    return {
+        primaryCategoryName: key.substring(0, separatorIndex),
+        subCategoryName: key.substring(separatorIndex + IMPORT_COMPOSITE_KEY_SEPARATOR.length)
+    };
+}
+
+// 构造"账户名 + 币种"的组合键
+// accountName: 账户名
+// accountCurrency: 账户币种（可能为空字符串）
+export function getImportAccountCompositeKey(accountName: string, accountCurrency: string): string {
+    return `${accountName}${IMPORT_COMPOSITE_KEY_SEPARATOR}${accountCurrency}`;
+}
+
+// 解析"账户名 + 币种"的组合键
+// key: 由 getImportAccountCompositeKey 生成的组合键
+export function parseImportAccountCompositeKey(key: string): { accountName: string, accountCurrency: string } {
+    const separatorIndex = key.indexOf(IMPORT_COMPOSITE_KEY_SEPARATOR);
+
+    if (separatorIndex < 0) {
+        return { accountName: key, accountCurrency: '' };
+    }
+
+    return {
+        accountName: key.substring(0, separatorIndex),
+        accountCurrency: key.substring(separatorIndex + IMPORT_COMPOSITE_KEY_SEPARATOR.length)
+    };
+}
+
 export class ImportTransaction implements ImportTransactionResponse {
     public type: number;
     public categoryId: string;
+    public originalPrimaryCategoryName: string;
     public originalCategoryName: string;
     public time: number;
     public utcOffset: number;
@@ -31,6 +80,7 @@ export class ImportTransaction implements ImportTransactionResponse {
     private constructor(response: ImportTransactionResponse, index: number) {
         this.type = response.type;
         this.categoryId = response.categoryId;
+        this.originalPrimaryCategoryName = response.originalPrimaryCategoryName || '';
         this.originalCategoryName = response.originalCategoryName;
         this.time = response.time;
         this.utcOffset = response.utcOffset;
@@ -124,6 +174,7 @@ export interface ImportTransactionRequestItem {
 export interface ImportTransactionResponse {
     readonly type: number;
     readonly categoryId: string;
+    readonly originalPrimaryCategoryName?: string;
     readonly originalCategoryName: string;
     readonly time: number;
     readonly utcOffset: number;

--- a/src/views/desktop/transactions/import/dialogs/BatchCreateDialog.vue
+++ b/src/views/desktop/transactions/import/dialogs/BatchCreateDialog.vue
@@ -6,6 +6,7 @@
                     <h4 class="text-h4 text-wrap" v-if="type === 'expenseCategory'">{{ tt('Create Nonexistent Expense Categories') }}</h4>
                     <h4 class="text-h4 text-wrap" v-if="type === 'incomeCategory'">{{ tt('Create Nonexistent Income Categories') }}</h4>
                     <h4 class="text-h4 text-wrap" v-if="type === 'transferCategory'">{{ tt('Create Nonexistent Transfer Categories') }}</h4>
+                    <h4 class="text-h4 text-wrap" v-if="type === 'account'">{{ tt('Create Nonexistent Accounts') }}</h4>
                     <h4 class="text-h4 text-wrap" v-if="type === 'tag'">{{ tt('Create Nonexistent Transaction Tags') }}</h4>
                     <v-spacer/>
                     <v-btn density="comfortable" color="default" variant="text" class="ms-2"
@@ -36,12 +37,12 @@
                         <v-list class="py-0" density="compact" select-strategy="classic"
                                 :disabled="submitting" v-model:selected="selectedNames">
                             <v-list-item class="mx-1 px-2 py-0"
-                                         :key="item.value" :value="item.name" :title="item.name"
+                                         :key="item.value" :value="item.value" :title="item.name"
                                          v-for="item in invalidItems">
                                 <template #prepend="{ isActive }">
                                     <v-list-item-action start>
                                         <v-checkbox-btn :model-value="isActive"
-                                                        @update:model-value="updateSelectedNames(item.name, $event)"></v-checkbox-btn>
+                                                        @update:model-value="updateSelectedNames(item.value, $event)"></v-checkbox-btn>
                                     </v-list-item-action>
                                 </template>
                             </v-list-item>
@@ -71,19 +72,25 @@ import { ref, useTemplateRef } from 'vue';
 
 import { useI18n } from '@/locales/helpers.ts';
 
+import { useUserStore } from '@/stores/user.ts';
+import { useAccountsStore } from '@/stores/account.ts';
 import { useTransactionCategoriesStore } from '@/stores/transactionCategory.ts';
 import { useTransactionTagsStore } from '@/stores/transactionTag.ts';
 
-import { type NameValue, values } from '@/core/base.ts';
+import { type NameValue, keys } from '@/core/base.ts';
 import { CategoryType } from '@/core/category.ts';
+import { AccountCategory } from '@/core/account.ts';
 import { AUTOMATICALLY_CREATED_CATEGORY_ICON_ID } from '@/consts/icon.ts';
 import { DEFAULT_CATEGORY_COLOR } from '@/consts/color.ts';
 import { DEFAULT_TAG_GROUP_ID } from '@/consts/tag.ts';
 
-import { type TransactionCategoryCreateRequest, type TransactionCategoryCreateWithSubCategories, TransactionCategory } from '@/models/transaction_category.ts';
+import { TransactionCategory } from '@/models/transaction_category.ts';
 import { type TransactionTagCreateRequest, TransactionTag } from '@/models/transaction_tag.ts';
+import { Account } from '@/models/account.ts';
+import { parseImportCategoryCompositeKey, parseImportAccountCompositeKey } from '@/models/imported_transaction.ts';
 
 import { isDefined, arrayItemToObjectField } from '@/lib/common.ts';
+import { getCurrentUnixTime } from '@/lib/datetime.ts';
 
 import {
     mdiSelectAll,
@@ -92,7 +99,7 @@ import {
     mdiDotsVertical
 } from '@mdi/js';
 
-export type BatchCreateDialogDataType = 'expenseCategory' | 'incomeCategory' | 'transferCategory' | 'tag';
+export type BatchCreateDialogDataType = 'expenseCategory' | 'incomeCategory' | 'transferCategory' | 'account' | 'tag';
 
 type SnackBarType = InstanceType<typeof SnackBar>;
 
@@ -102,6 +109,8 @@ interface BatchCreateDialogResponse {
 
 const { tt } = useI18n();
 
+const userStore = useUserStore();
+const accountsStore = useAccountsStore();
 const transactionCategoriesStore = useTransactionCategoriesStore();
 const transactionTagsStore = useTransactionTagsStore();
 
@@ -132,55 +141,124 @@ function updateSelectedNames(value: string, selected: boolean | null): void {
     selectedNames.value = newSelectedNames;
 }
 
-function buildBatchCreateCategoryResponse(createdCategories: Record<number, TransactionCategory[]>): BatchCreateDialogResponse {
-    const displayNameSourceItemMap: Record<string, string> = {};
+interface SelectedCategoryItem {
+    // 选项 value（"一级名 + 二级名"组合键，一级可能为空）
+    compositeKey: string;
+    // 原始一级名（可能为空，空时回退到默认一级名）
+    primaryCategoryName: string;
+    // 二级名
+    subCategoryName: string;
+}
+
+// 按一级分类分组创建：一级已存在则复用、不存在则创建，再在其下创建缺失的二级，
+// 返回 组合键 -> 新建/复用的二级分类 id 的映射，供调用方回填交易的 categoryId
+// categoryType: 分类类型（支出/收入/转账）
+// defaultPrimaryCategoryName: 当原始一级名为空时使用的默认一级名
+// selectedItems: 用户在对话框中选中的待创建项
+async function createCategoriesHierarchically(categoryType: CategoryType, defaultPrimaryCategoryName: string, selectedItems: SelectedCategoryItem[]): Promise<Record<string, string>> {
     const sourceTargetMap: Record<string, string> = {};
 
-    for (const item of (invalidItems.value || [])) {
-        displayNameSourceItemMap[item.name] = item.value;
+    // 按"实际使用的一级名"分组（原始一级为空时回退到默认一级名）
+    const groupedItems: Record<string, SelectedCategoryItem[]> = {};
+
+    for (const item of selectedItems) {
+        const primaryCategoryName = item.primaryCategoryName || defaultPrimaryCategoryName;
+
+        if (!groupedItems[primaryCategoryName]) {
+            groupedItems[primaryCategoryName] = [];
+        }
+
+        groupedItems[primaryCategoryName]!.push(item);
     }
 
-    for (const categories of values(createdCategories)) {
-        for (const category of categories) {
-            if (!category.subCategories || category.subCategories.length < 1) {
+    for (const primaryCategoryName of keys(groupedItems)) {
+        // 查找已存在的同名一级分类，存在则复用，否则新建一级
+        const existingPrimaryCategories = transactionCategoriesStore.allTransactionCategories[categoryType] || [];
+        let parentCategory: TransactionCategory | undefined = existingPrimaryCategories.find(category => category.name === primaryCategoryName);
+
+        if (!parentCategory) {
+            const newPrimaryCategory = TransactionCategory.createNewCategory(categoryType);
+            newPrimaryCategory.name = primaryCategoryName;
+            newPrimaryCategory.icon = AUTOMATICALLY_CREATED_CATEGORY_ICON_ID;
+            newPrimaryCategory.color = DEFAULT_CATEGORY_COLOR;
+            parentCategory = await transactionCategoriesStore.saveCategory({ category: newPrimaryCategory, isEdit: false, clientSessionId: '' });
+        }
+
+        // 该一级下已存在的二级名 -> id，用于复用并避免重复创建
+        const subCategoryIdByName: Record<string, string> = {};
+
+        for (const subCategory of (parentCategory.subCategories || [])) {
+            subCategoryIdByName[subCategory.name] = subCategory.id;
+        }
+
+        for (const item of groupedItems[primaryCategoryName]!) {
+            const existingSubCategoryId = subCategoryIdByName[item.subCategoryName];
+
+            if (isDefined(existingSubCategoryId)) {
+                sourceTargetMap[item.compositeKey] = existingSubCategoryId;
                 continue;
             }
 
-            for (const subCategory of category.subCategories) {
-                const sourceItem = displayNameSourceItemMap[subCategory.name];
+            const newSubCategory = TransactionCategory.createNewCategory(categoryType, parentCategory.id);
+            newSubCategory.name = item.subCategoryName;
+            newSubCategory.icon = AUTOMATICALLY_CREATED_CATEGORY_ICON_ID;
+            const createdSubCategory = await transactionCategoriesStore.saveCategory({ category: newSubCategory, isEdit: false, clientSessionId: '' });
 
-                if (!isDefined(sourceItem)) {
-                    continue;
-                }
-
-                sourceTargetMap[sourceItem] = subCategory.id;
-            }
+            subCategoryIdByName[item.subCategoryName] = createdSubCategory.id;
+            sourceTargetMap[item.compositeKey] = createdSubCategory.id;
         }
     }
 
-    const response: BatchCreateDialogResponse = {
-        sourceTargetMap: sourceTargetMap
-    };
-
-    return response;
+    return sourceTargetMap;
 }
 
-function buildBatchCreateTagResponse(createdTags: TransactionTag[]): BatchCreateDialogResponse {
-    const displayNameSourceItemMap: Record<string, string> = {};
+// 逐个创建不存在的账户：账户分类默认用"现金"，币种取自 CSV（缺失时回退用户默认币种），
+// 返回 账户名 -> 新建账户 id 的映射，供调用方回填交易的 sourceAccountId / destinationAccountId
+// selectedKeys: 用户选中的"账户名 + 币种"组合键列表
+async function createNonexistentAccounts(selectedKeys: string[]): Promise<Record<string, string>> {
     const sourceTargetMap: Record<string, string> = {};
+    const balanceTime = getCurrentUnixTime();
 
-    for (const item of (invalidItems.value || [])) {
-        displayNameSourceItemMap[item.name] = item.value;
-    }
+    for (const compositeKey of selectedKeys) {
+        const parsed = parseImportAccountCompositeKey(compositeKey);
+        const accountName = parsed.accountName;
+        const accountCurrency = parsed.accountCurrency || userStore.currentUserDefaultCurrency;
 
-    for (const tag of createdTags) {
-        const sourceItem = displayNameSourceItemMap[tag.name];
+        // 已存在同名账户则直接复用，避免重复创建
+        const existingAccount = accountsStore.allAccounts.find(account => account.name === accountName);
 
-        if (!isDefined(sourceItem)) {
+        if (existingAccount) {
+            sourceTargetMap[accountName] = existingAccount.id;
             continue;
         }
 
-        sourceTargetMap[sourceItem] = tag.id;
+        const newAccount = Account.createNewAccount(AccountCategory.Cash, accountCurrency, balanceTime);
+        newAccount.name = accountName;
+
+        const createdAccount = await accountsStore.saveAccount({ account: newAccount, subAccounts: [], isEdit: false, clientSessionId: '' });
+        sourceTargetMap[accountName] = createdAccount.id;
+    }
+
+    return sourceTargetMap;
+}
+
+function buildBatchCreateTagResponse(createdTags: TransactionTag[]): BatchCreateDialogResponse {
+    const createdTagIdMap: Record<string, string> = {};
+    const sourceTargetMap: Record<string, string> = {};
+
+    // 新建标签名 -> id（标签的 value 即为标签名本身）
+    for (const tag of createdTags) {
+        createdTagIdMap[tag.name] = tag.id;
+    }
+
+    for (const item of (invalidItems.value || [])) {
+        const targetItem = createdTagIdMap[item.value];
+
+        if (!isDefined(targetItem)) {
+            continue;
+        }
+
+        sourceTargetMap[item.value] = targetItem;
     }
 
     const response: BatchCreateDialogResponse = {
@@ -204,7 +282,7 @@ function open(options: { type: BatchCreateDialogDataType, invalidItems?: NameVal
 }
 
 function selectAllItems(): void {
-    selectedNames.value = (invalidItems.value || []).map(item => item.name);
+    selectedNames.value = (invalidItems.value || []).map(item => item.value);
 }
 
 function selectNoneItems(): void {
@@ -216,8 +294,8 @@ function selectInvertItems(): void {
     selectedNames.value = [];
 
     for (const item of (invalidItems.value || [])) {
-        if (!currentSelectedNames[item.name]) {
-            selectedNames.value.push(item.name);
+        if (!currentSelectedNames[item.value]) {
+            selectedNames.value.push(item.value);
         }
     }
 }
@@ -227,44 +305,35 @@ function confirm(): void {
         submitting.value = true;
 
         let categoryType: CategoryType = CategoryType.Expense;
-        let primaryCategoryName = '';
+        let defaultPrimaryCategoryName = '';
 
         if (type.value === 'expenseCategory') {
             categoryType = CategoryType.Expense;
-            primaryCategoryName = tt('Default Expense Category');
+            defaultPrimaryCategoryName = tt('Default Expense Category');
         } else if (type.value === 'incomeCategory') {
             categoryType = CategoryType.Income;
-            primaryCategoryName = tt('Default Income Category');
+            defaultPrimaryCategoryName = tt('Default Income Category');
         } else if (type.value === 'transferCategory') {
             categoryType = CategoryType.Transfer;
-            primaryCategoryName = tt('Default Transfer Category');
+            defaultPrimaryCategoryName = tt('Default Transfer Category');
         }
 
-        const subCategories: TransactionCategoryCreateRequest[] = [];
+        // 解析选中项：每项携带原始一级名（可能为空）与二级名
+        const selectedItems: SelectedCategoryItem[] = selectedNames.value.map(compositeKey => {
+            const parsed = parseImportCategoryCompositeKey(compositeKey);
+            return {
+                compositeKey: compositeKey,
+                primaryCategoryName: parsed.primaryCategoryName,
+                subCategoryName: parsed.subCategoryName
+            };
+        });
 
-        for (const item of selectedNames.value) {
-            const category: TransactionCategory = TransactionCategory.createNewCategory(categoryType);
-            category.name = item;
-            category.icon = AUTOMATICALLY_CREATED_CATEGORY_ICON_ID;
-            subCategories.push(category.toCreateRequest(''));
-        }
-
-        const submitCategories: TransactionCategoryCreateWithSubCategories[] = [{
-            name: primaryCategoryName,
-            type: categoryType,
-            icon: AUTOMATICALLY_CREATED_CATEGORY_ICON_ID,
-            color: DEFAULT_CATEGORY_COLOR,
-            subCategories: subCategories
-        }];
-
-        transactionCategoriesStore.addCategories({
-            categories: submitCategories
-        }).then(response => {
+        createCategoriesHierarchically(categoryType, defaultPrimaryCategoryName, selectedItems).then(sourceTargetMap => {
             transactionCategoriesStore.loadAllCategories({ force: false }).then(() => {
                 submitting.value = false;
                 showState.value = false;
 
-                resolveFunc?.(buildBatchCreateCategoryResponse(response));
+                resolveFunc?.({ sourceTargetMap: sourceTargetMap });
             }).catch(error => {
                 submitting.value = false;
 
@@ -306,6 +375,21 @@ function confirm(): void {
                     snackbar.value?.showError(error);
                 }
             });
+        }).catch(error => {
+            submitting.value = false;
+
+            if (!error.processed) {
+                snackbar.value?.showError(error);
+            }
+        });
+    } else if (type.value === 'account') {
+        submitting.value = true;
+
+        createNonexistentAccounts(selectedNames.value).then(sourceTargetMap => {
+            submitting.value = false;
+            showState.value = false;
+
+            resolveFunc?.({ sourceTargetMap: sourceTargetMap });
         }).catch(error => {
             submitting.value = false;
 

--- a/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
+++ b/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
@@ -425,7 +425,7 @@ import { ImportTransactionColumnType } from '@/core/import_transaction.ts';
 import { Account, type CategorizedAccountWithDisplayBalance } from '@/models/account.ts';
 import type { TransactionCategory } from '@/models/transaction_category.ts';
 import { TransactionTag } from '@/models/transaction_tag.ts';
-import { ImportTransaction } from '@/models/imported_transaction.ts';
+import { ImportTransaction, getImportCategoryCompositeKey, getImportAccountCompositeKey } from '@/models/imported_transaction.ts';
 
 import {
     isString,
@@ -898,6 +898,12 @@ const toolMenus = computed<ImportTransactionCheckDataMenu[]>(() => [
     },
     {
         prependIcon: mdiShapePlusOutline,
+        title: tt('Create Nonexistent Accounts'),
+        disabled: isEditing.value || !allInvalidAccountItemsForCreate.value || allInvalidAccountItemsForCreate.value.length < 1,
+        onClick: () => showBatchCreateInvalidItemDialog('account', allInvalidAccountItemsForCreate.value)
+    },
+    {
+        prependIcon: mdiShapePlusOutline,
         title: tt('Create Nonexistent Transaction Tags'),
         disabled: isEditing.value || !allInvalidTransactionTagNames.value || allInvalidTransactionTagNames.value.length < 1,
         onClick: () => showBatchCreateInvalidItemDialog('tag', allInvalidTransactionTagNames.value)
@@ -1190,6 +1196,7 @@ const allInvalidExpenseCategoryNames = computed<NameValue[]>(() => getCurrentInv
 const allInvalidIncomeCategoryNames = computed<NameValue[]>(() => getCurrentInvalidCategoryNames(TransactionType.Income));
 const allInvalidTransferCategoryNames = computed<NameValue[]>(() => getCurrentInvalidCategoryNames(TransactionType.Transfer));
 const allInvalidAccountNames = computed<NameValue[]>(() => getCurrentInvalidAccountNames());
+const allInvalidAccountItemsForCreate = computed<NameValue[]>(() => getCurrentInvalidAccountNamesForCreate());
 const allInvalidTransactionTagNames = computed<NameValue[]>(() => getCurrentInvalidTagNames());
 const allOriginalTransactionTagNames = computed<NameValue[]>(() => getAllOriginalTagNames());
 
@@ -1418,7 +1425,7 @@ function getDestinationAccountDisplayName(transaction: ImportTransaction): strin
 }
 
 function getCurrentInvalidCategoryNames(transactionType: TransactionType): NameValue[] {
-    const invalidCategoryNames: Record<string, boolean> = {};
+    const invalidCategoryKeys: Record<string, boolean> = {};
     const invalidCategories: NameValue[] = [];
 
     if (!props.importTransactions || props.importTransactions.length < 1) {
@@ -1429,15 +1436,31 @@ function getCurrentInvalidCategoryNames(transactionType: TransactionType): NameV
         const categoryId = importTransaction.categoryId;
 
         if (importTransaction.type === transactionType && (!categoryId || categoryId === '0' || !allCategoriesMap.value[categoryId])) {
-            invalidCategoryNames[importTransaction.originalCategoryName] = true;
-        }
-    }
+            const primaryCategoryName = importTransaction.originalPrimaryCategoryName || '';
+            const subCategoryName = importTransaction.originalCategoryName;
+            // 用"一级名 + 二级名"的组合键去重，避免不同一级下的同名二级被合并
+            const compositeKey = getImportCategoryCompositeKey(primaryCategoryName, subCategoryName);
 
-    for (const name of keys(invalidCategoryNames)) {
-        invalidCategories.push({
-            name: name || tt('(Empty)'),
-            value: name
-        });
+            if (invalidCategoryKeys[compositeKey]) {
+                continue;
+            }
+
+            invalidCategoryKeys[compositeKey] = true;
+
+            // 列表展示名：有一级时显示"一级 / 二级"，否则只显示二级（空则显示占位符）
+            let displayName: string;
+
+            if (primaryCategoryName) {
+                displayName = `${primaryCategoryName} / ${subCategoryName || tt('(Empty)')}`;
+            } else {
+                displayName = subCategoryName || tt('(Empty)');
+            }
+
+            invalidCategories.push({
+                name: displayName,
+                value: compositeKey
+            });
+        }
     }
 
     return invalidCategories;
@@ -1469,6 +1492,49 @@ function getCurrentInvalidAccountNames(): NameValue[] {
             name: name || tt('(Empty)'),
             value: name
         });
+    }
+
+    return invalidAccounts;
+}
+
+// 收集需要"创建"的无效账户：value 用"账户名 + 币种"组合键以携带币种（创建账户时需要），name 仅展示账户名。
+// 与 getCurrentInvalidAccountNames 区分开，后者 value=账户名 用于"替换"流程的匹配，不能改动。
+function getCurrentInvalidAccountNamesForCreate(): NameValue[] {
+    const invalidAccountNames: Record<string, boolean> = {};
+    const invalidAccounts: NameValue[] = [];
+
+    if (!props.importTransactions || props.importTransactions.length < 1) {
+        return invalidAccounts;
+    }
+
+    for (const importTransaction of props.importTransactions) {
+        const sourceAccountId = importTransaction.sourceAccountId;
+        const destinationAccountId = importTransaction.destinationAccountId;
+
+        if (!sourceAccountId || sourceAccountId === '0' || !allAccountsMap.value[sourceAccountId]) {
+            const accountName = importTransaction.originalSourceAccountName;
+
+            // 同名账户只取首次出现的币种（正常导出中同名账户币种一致）
+            if (!invalidAccountNames[accountName]) {
+                invalidAccountNames[accountName] = true;
+                invalidAccounts.push({
+                    name: accountName || tt('(Empty)'),
+                    value: getImportAccountCompositeKey(accountName, importTransaction.originalSourceAccountCurrency || '')
+                });
+            }
+        }
+
+        if (importTransaction.type === TransactionType.Transfer && isString(importTransaction.originalDestinationAccountName) && (!destinationAccountId || destinationAccountId === '0' || !allAccountsMap.value[destinationAccountId])) {
+            const accountName = importTransaction.originalDestinationAccountName;
+
+            if (!invalidAccountNames[accountName]) {
+                invalidAccountNames[accountName] = true;
+                invalidAccounts.push({
+                    name: accountName || tt('(Empty)'),
+                    value: getImportAccountCompositeKey(accountName, importTransaction.originalDestinationAccountCurrency || '')
+                });
+            }
+        }
     }
 
     return invalidAccounts;
@@ -2045,8 +2111,9 @@ function showBatchCreateInvalidItemDialog(type: BatchCreateDialogDataType, inval
 
                 if (type === 'expenseCategory' || type === 'incomeCategory' || type === 'transferCategory') {
                     const categoryId = importTransaction.categoryId;
-                    const originalCategoryName = importTransaction.originalCategoryName;
-                    const targetItem = sourceTargetMap[originalCategoryName];
+                    // 用"一级名 + 二级名"的组合键回填，确保对应到正确一级下的二级分类
+                    const compositeKey = getImportCategoryCompositeKey(importTransaction.originalPrimaryCategoryName || '', importTransaction.originalCategoryName);
+                    const targetItem = sourceTargetMap[compositeKey];
 
                     if (importTransaction.type !== TransactionType.ModifyBalance && targetItem && (!categoryId || categoryId === '0' || !allCategoriesMap.value[categoryId])) {
                         if (type === 'expenseCategory' && importTransaction.type === TransactionType.Expense) {
@@ -2068,6 +2135,25 @@ function showBatchCreateInvalidItemDialog(type: BatchCreateDialogDataType, inval
 
                         if (targetItem && (!tagId || tagId === '0' || !allTagsMap.value[tagId])) {
                             importTransaction.tagIds[tagIndex] = targetItem;
+                            updated = true;
+                        }
+                    }
+                } else if (type === 'account') {
+                    // sourceTargetMap 以"账户名"为 key 映射到新建账户 id
+                    const sourceAccountId = importTransaction.sourceAccountId;
+                    const sourceTargetItem = sourceTargetMap[importTransaction.originalSourceAccountName];
+
+                    if (sourceTargetItem && (!sourceAccountId || sourceAccountId === '0' || !allAccountsMap.value[sourceAccountId])) {
+                        importTransaction.sourceAccountId = sourceTargetItem;
+                        updated = true;
+                    }
+
+                    if (importTransaction.type === TransactionType.Transfer && isString(importTransaction.originalDestinationAccountName)) {
+                        const destinationAccountId = importTransaction.destinationAccountId;
+                        const destinationTargetItem = sourceTargetMap[importTransaction.originalDestinationAccountName];
+
+                        if (destinationTargetItem && (!destinationAccountId || destinationAccountId === '0' || !allAccountsMap.value[destinationAccountId])) {
+                            importTransaction.destinationAccountId = destinationTargetItem;
                             updated = true;
                         }
                     }


### PR DESCRIPTION
## What
Support creating nonexistent **accounts** and creating **hierarchical categories** on the transaction import check page.

## Why
Previously "Create Nonexistent Expense/Income/Transfer Categories" only created second-level categories and placed all of them under a single hardcoded default primary category. There was also no way to create missing accounts from the import check page.

## Changes
- **Backend**: add `OriginalPrimaryCategoryName` to the import transaction model/response and populate it in the data-table importer, so the frontend receives the primary (first-level) category name.
- **Categories**: create categories hierarchically — reuse an existing primary category if present, otherwise create it, and place each sub-category under its corresponding primary. A composite key (primary + sub name) avoids mixing up sub-categories that share the same name under different primaries.
- **Accounts**: add a "Create Nonexistent Accounts" menu item; new accounts default to the Cash category and use the currency from the imported data.
- **i18n**: add en / zh_Hans / zh_Hant strings.

## Notes
Backward compatible: when the primary category name is absent, sub-categories fall back to the default primary category (previous behavior).
