### PR TITLE
add ArgentinaDatos HTTP exchange rates datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ ezbookkeeping
 /data/
 /storage/
 /log/
+
+.codex
+.planning/

--- a/conf/ezbookkeeping.ini
+++ b/conf/ezbookkeeping.ini
@@ -658,8 +658,16 @@ custom_map_tile_server_default_zoom_level = 14
 # "swiss_national_bank": https://www.snb.ch/en/the-snb/mandates-goals/statistics/statistics-pub/current_interest_exchange_rates
 # "national_bank_of_ukraine": https://bank.gov.ua/ua/markets/exchangerates
 # "central_bank_of_uzbekistan": https://cbu.uz/en/arkhiv-kursov-valyut/
+# "argentina_datos": https://argentinadatos.com/docs/operations/get-cotizaciones-dolares
 # "user_custom": users set their own exchange rates data in the UI
 data_source = euro_central_bank
+
+# For "argentina_datos" data source only, dollar exchange house
+# Supported exchange house values: oficial, blue, bolsa, contadoconliqui, cripto, mayorista, solidario, turista
+argentina_datos_exchange_house = blue
+
+# For "argentina_datos" data source only, use "buy" or "sell", default is "sell"
+argentina_datos_rate_type = sell
 
 # Requesting exchange rates data timeout (0 - 4294967295 milliseconds)
 # Set to 0 to disable timeout for requesting exchange rates data, default is 10000 (10 seconds)

--- a/pkg/exchangerates/argentina_datos_datasource.go
+++ b/pkg/exchangerates/argentina_datos_datasource.go
@@ -1,0 +1,168 @@
+package exchangerates
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mayswind/ezbookkeeping/pkg/core"
+	"github.com/mayswind/ezbookkeeping/pkg/errs"
+	"github.com/mayswind/ezbookkeeping/pkg/log"
+	"github.com/mayswind/ezbookkeeping/pkg/models"
+	"github.com/mayswind/ezbookkeeping/pkg/settings"
+	"github.com/mayswind/ezbookkeeping/pkg/utils"
+)
+
+const (
+	argentinaDatosExchangeRateReferenceUrl = "https://argentinadatos.com/docs/operations/get-cotizaciones-dolares"
+	argentinaDatosExchangeRateUrlTemplate  = "https://api.argentinadatos.com/v1/cotizaciones/dolares/%s"
+	argentinaDatosDataSource               = "ArgentinaDatos"
+	argentinaDatosBaseCurrency             = "ARS"
+
+	// ArgentinaDatos API rate type values
+	argentinaDatosApiRateTypeBuy  = "compra"
+	argentinaDatosApiRateTypeSell = "venta"
+)
+
+var argentinaDatosValidExchangeHouses = map[string]bool{
+	"oficial":         true,
+	"blue":            true,
+	"bolsa":           true,
+	"contadoconliqui": true,
+	"cripto":          true,
+	"mayorista":       true,
+	"solidario":       true,
+	"turista":         true,
+}
+
+// ArgentinaDatosDataSource defines the structure of exchange rates data source of ArgentinaDatos API
+type ArgentinaDatosDataSource struct {
+	HttpExchangeRatesDataSource
+	exchangeHouse string
+	apiRateType   string
+}
+
+// ArgentinaDatosQuote represents a single dollar exchange rate quote from ArgentinaDatos API
+type ArgentinaDatosQuote struct {
+	ExchangeHouse string  `json:"casa"`
+	Buy           float64 `json:"compra"`
+	Sell          float64 `json:"venta"`
+	Date          string  `json:"fecha"`
+}
+
+// IsValidArgentinaDatosExchangeHouse returns whether the given exchange house name is supported by ArgentinaDatos API
+func IsValidArgentinaDatosExchangeHouse(exchangeHouse string) bool {
+	return argentinaDatosValidExchangeHouses[strings.ToLower(exchangeHouse)]
+}
+
+func mapConfigRateTypeToArgentinaDatosApiRateType(rateType string) string {
+	if rateType == settings.ArgentinaDatosRateTypeBuy {
+		return argentinaDatosApiRateTypeBuy
+	}
+
+	return argentinaDatosApiRateTypeSell
+}
+
+func newArgentinaDatosDataSource(config *settings.Config) *ArgentinaDatosDataSource {
+	exchangeHouse := config.ExchangeRatesArgentinaDatosExchangeHouse
+
+	if exchangeHouse == "" {
+		exchangeHouse = "blue"
+	}
+
+	rateType := config.ExchangeRatesArgentinaDatosRateType
+
+	if rateType != settings.ArgentinaDatosRateTypeBuy && rateType != settings.ArgentinaDatosRateTypeSell {
+		rateType = settings.ArgentinaDatosRateTypeSell
+	}
+
+	return &ArgentinaDatosDataSource{
+		exchangeHouse: strings.ToLower(exchangeHouse),
+		apiRateType:   mapConfigRateTypeToArgentinaDatosApiRateType(rateType),
+	}
+}
+
+func (q *ArgentinaDatosQuote) getRateByApiRateType(apiRateType string) float64 {
+	if q == nil {
+		return 0
+	}
+
+	if apiRateType == argentinaDatosApiRateTypeBuy {
+		return q.Buy
+	}
+
+	return q.Sell
+}
+
+func (e *ArgentinaDatosDataSource) getArsPerUsd(quote *ArgentinaDatosQuote) float64 {
+	return quote.getRateByApiRateType(e.apiRateType)
+}
+
+func (e *ArgentinaDatosDataSource) ToLatestExchangeRateResponse(c core.Context, content []byte) *models.LatestExchangeRateResponse {
+	var quotes []ArgentinaDatosQuote
+	err := json.Unmarshal(content, &quotes)
+
+	if err != nil {
+		log.Errorf(c, "[argentina_datos_datasource.ToLatestExchangeRateResponse] failed to parse json data, because %s", err.Error())
+		return nil
+	}
+
+	if len(quotes) < 1 {
+		log.Errorf(c, "[argentina_datos_datasource.ToLatestExchangeRateResponse] quotes is empty")
+		return nil
+	}
+
+	latestQuote := quotes[len(quotes)-1]
+	arsPerUsd := e.getArsPerUsd(&latestQuote)
+
+	if arsPerUsd <= 0 {
+		log.Errorf(c, "[argentina_datos_datasource.ToLatestExchangeRateResponse] rate is invalid, ars per usd is %f", arsPerUsd)
+		return nil
+	}
+
+	updateTime, err := time.Parse("2006-01-02", latestQuote.Date)
+
+	if err != nil {
+		log.Errorf(c, "[argentina_datos_datasource.ToLatestExchangeRateResponse] failed to parse update date, date is %s", latestQuote.Date)
+		return nil
+	}
+
+	return &models.LatestExchangeRateResponse{
+		DataSource:   argentinaDatosDataSource,
+		ReferenceUrl: argentinaDatosExchangeRateReferenceUrl,
+		UpdateTime:   updateTime.Unix(),
+		BaseCurrency: argentinaDatosBaseCurrency,
+		ExchangeRates: models.LatestExchangeRateSlice{
+			{
+				Currency: "USD",
+				Rate:     utils.Float64ToString(1 / arsPerUsd),
+			},
+		},
+	}
+}
+
+// BuildRequests returns the ArgentinaDatos exchange rates http requests
+func (e *ArgentinaDatosDataSource) BuildRequests() ([]*http.Request, error) {
+	requestUrl := fmt.Sprintf(argentinaDatosExchangeRateUrlTemplate, e.exchangeHouse)
+	req, err := http.NewRequest("GET", requestUrl, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return []*http.Request{req}, nil
+}
+
+// Parse returns the common response entity according to the ArgentinaDatos data source raw response
+func (e *ArgentinaDatosDataSource) Parse(c core.Context, content []byte) (*models.LatestExchangeRateResponse, error) {
+	latestExchangeRateResponse := e.ToLatestExchangeRateResponse(c, content)
+
+	if latestExchangeRateResponse == nil {
+		log.Errorf(c, "[argentina_datos_datasource.Parse] failed to parse latest exchange rate data, content is %s", string(content))
+		return nil, errs.ErrFailedToRequestRemoteApi
+	}
+
+	return latestExchangeRateResponse, nil
+}

--- a/pkg/exchangerates/argentina_datos_datasource_test.go
+++ b/pkg/exchangerates/argentina_datos_datasource_test.go
@@ -1,0 +1,231 @@
+package exchangerates
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mayswind/ezbookkeeping/pkg/core"
+	"github.com/mayswind/ezbookkeeping/pkg/errs"
+	"github.com/mayswind/ezbookkeeping/pkg/models"
+	"github.com/mayswind/ezbookkeeping/pkg/settings"
+)
+
+const argentinaDatosMinimumRequiredContent = "[\n" +
+	"  {\n" +
+	"    \"casa\": \"blue\",\n" +
+	"    \"compra\": 1490,\n" +
+	"    \"venta\": 1510,\n" +
+	"    \"fecha\": \"2026-07-06\"\n" +
+	"  },\n" +
+	"  {\n" +
+	"    \"casa\": \"blue\",\n" +
+	"    \"compra\": 1495,\n" +
+	"    \"venta\": 1515,\n" +
+	"    \"fecha\": \"2026-07-07\"\n" +
+	"  }\n" +
+	"]"
+
+func TestMapConfigRateTypeToArgentinaDatosApiRateType(t *testing.T) {
+	assert.Equal(t, argentinaDatosApiRateTypeBuy, mapConfigRateTypeToArgentinaDatosApiRateType(settings.ArgentinaDatosRateTypeBuy))
+	assert.Equal(t, argentinaDatosApiRateTypeSell, mapConfigRateTypeToArgentinaDatosApiRateType(settings.ArgentinaDatosRateTypeSell))
+	assert.Equal(t, argentinaDatosApiRateTypeSell, mapConfigRateTypeToArgentinaDatosApiRateType("invalid"))
+}
+
+func TestArgentinaDatosDataSource_StandardDataExtractBaseCurrency(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	actualLatestExchangeRateResponse, err := dataSource.Parse(context, []byte(argentinaDatosMinimumRequiredContent))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "ARS", actualLatestExchangeRateResponse.BaseCurrency)
+}
+
+func TestArgentinaDatosDataSource_StandardDataExtractUpdateTime(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	actualLatestExchangeRateResponse, err := dataSource.Parse(context, []byte(argentinaDatosMinimumRequiredContent))
+	assert.Equal(t, nil, err)
+
+	expectedUpdateTime, _ := time.Parse("2006-01-02", "2026-07-07")
+	assert.Equal(t, expectedUpdateTime.Unix(), actualLatestExchangeRateResponse.UpdateTime)
+}
+
+func TestArgentinaDatosDataSource_StandardDataExtractExchangeRates(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	actualLatestExchangeRateResponse, err := dataSource.Parse(context, []byte(argentinaDatosMinimumRequiredContent))
+	assert.Equal(t, nil, err)
+	assert.Contains(t, actualLatestExchangeRateResponse.ExchangeRates, &models.LatestExchangeRate{
+		Currency: "USD",
+		Rate:     "0.0006600660066006601",
+	})
+}
+
+func TestArgentinaDatosDataSource_BuyRateType(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeBuy,
+	}
+	context := core.NewNullContext()
+
+	actualLatestExchangeRateResponse, err := dataSource.Parse(context, []byte(argentinaDatosMinimumRequiredContent))
+	assert.Equal(t, nil, err)
+	assert.Contains(t, actualLatestExchangeRateResponse.ExchangeRates, &models.LatestExchangeRate{
+		Currency: "USD",
+		Rate:     "0.0006688963210702341",
+	})
+}
+
+func TestArgentinaDatosDataSource_BlankContent(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	_, err := dataSource.Parse(context, []byte(""))
+	assert.NotEqual(t, nil, err)
+}
+
+func TestArgentinaDatosDataSource_EmptyArray(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	_, err := dataSource.Parse(context, []byte("[]"))
+	assert.NotEqual(t, nil, err)
+}
+
+func TestIsValidArgentinaDatosExchangeHouse(t *testing.T) {
+	assert.True(t, IsValidArgentinaDatosExchangeHouse("blue"))
+	assert.True(t, IsValidArgentinaDatosExchangeHouse("BLUE"))
+	assert.False(t, IsValidArgentinaDatosExchangeHouse("invalid"))
+}
+
+func TestNewArgentinaDatosDataSource_DefaultExchangeHouse(t *testing.T) {
+	dataSource := newArgentinaDatosDataSource(&settings.Config{})
+
+	assert.Equal(t, "blue", dataSource.exchangeHouse)
+	assert.Equal(t, argentinaDatosApiRateTypeSell, dataSource.apiRateType)
+}
+
+func TestNewArgentinaDatosDataSource_BuyRateTypeMapping(t *testing.T) {
+	dataSource := newArgentinaDatosDataSource(&settings.Config{
+		ExchangeRatesArgentinaDatosRateType: settings.ArgentinaDatosRateTypeBuy,
+	})
+
+	assert.Equal(t, argentinaDatosApiRateTypeBuy, dataSource.apiRateType)
+}
+
+func TestArgentinaDatosDataSource_BuildRequests_BlueExchangeHouse(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+
+	requests, err := dataSource.BuildRequests()
+	assert.Equal(t, nil, err)
+	assert.Len(t, requests, 1)
+	assert.Equal(t, http.MethodGet, requests[0].Method)
+	assert.Equal(t, "https://api.argentinadatos.com/v1/cotizaciones/dolares/blue", requests[0].URL.String())
+}
+
+func TestArgentinaDatosDataSource_LatestEntrySelection(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	content := "[\n" +
+		"  {\n" +
+		"    \"casa\": \"blue\",\n" +
+		"    \"compra\": 1000,\n" +
+		"    \"venta\": 1100,\n" +
+		"    \"fecha\": \"2026-01-01\"\n" +
+		"  },\n" +
+		"  {\n" +
+		"    \"casa\": \"blue\",\n" +
+		"    \"compra\": 1495,\n" +
+		"    \"venta\": 1515,\n" +
+		"    \"fecha\": \"2026-07-07\"\n" +
+		"  }\n" +
+		"]"
+
+	actualLatestExchangeRateResponse, err := dataSource.Parse(context, []byte(content))
+	assert.Equal(t, nil, err)
+
+	expectedUpdateTime, _ := time.Parse("2006-01-02", "2026-07-07")
+	assert.Equal(t, expectedUpdateTime.Unix(), actualLatestExchangeRateResponse.UpdateTime)
+	assert.Contains(t, actualLatestExchangeRateResponse.ExchangeRates, &models.LatestExchangeRate{
+		Currency: "USD",
+		Rate:     "0.0006600660066006601",
+	})
+}
+
+func TestArgentinaDatosDataSource_InvalidJson(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	_, err := dataSource.Parse(context, []byte("not-json"))
+	assert.Equal(t, errs.ErrFailedToRequestRemoteApi, err)
+}
+
+func TestArgentinaDatosDataSource_ZeroRate(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	content := "[\n" +
+		"  {\n" +
+		"    \"casa\": \"blue\",\n" +
+		"    \"compra\": 0,\n" +
+		"    \"venta\": 0,\n" +
+		"    \"fecha\": \"2026-07-07\"\n" +
+		"  }\n" +
+		"]"
+
+	_, err := dataSource.Parse(context, []byte(content))
+	assert.Equal(t, errs.ErrFailedToRequestRemoteApi, err)
+}
+
+func TestArgentinaDatosDataSource_InvalidDate(t *testing.T) {
+	dataSource := &ArgentinaDatosDataSource{
+		exchangeHouse: "blue",
+		apiRateType:   argentinaDatosApiRateTypeSell,
+	}
+	context := core.NewNullContext()
+
+	content := "[\n" +
+		"  {\n" +
+		"    \"casa\": \"blue\",\n" +
+		"    \"compra\": 1495,\n" +
+		"    \"venta\": 1515,\n" +
+		"    \"fecha\": \"not-a-date\"\n" +
+		"  }\n" +
+		"]"
+
+	_, err := dataSource.Parse(context, []byte(content))
+	assert.Equal(t, errs.ErrFailedToRequestRemoteApi, err)
+}

--- a/pkg/exchangerates/exchange_rates_data_provider_container.go
+++ b/pkg/exchangerates/exchange_rates_data_provider_container.go
@@ -67,6 +67,13 @@ func InitializeExchangeRatesDataSource(config *settings.Config) error {
 	} else if config.ExchangeRatesDataSource == settings.CentralBankOfUzbekistanDataSource {
 		Container.current = newCommonHttpExchangeRatesDataProvider(config, &CentralBankOfUzbekistanDataSource{})
 		return nil
+	} else if config.ExchangeRatesDataSource == settings.ArgentinaDatosDataSource {
+		if !IsValidArgentinaDatosExchangeHouse(config.ExchangeRatesArgentinaDatosExchangeHouse) && config.ExchangeRatesArgentinaDatosExchangeHouse != "" {
+			return errs.ErrInvalidExchangeRatesDataSource
+		}
+
+		Container.current = newCommonHttpExchangeRatesDataProvider(config, newArgentinaDatosDataSource(config))
+		return nil
 	} else if config.ExchangeRatesDataSource == settings.UserCustomExchangeRatesDataSource {
 		Container.current = newUserCustomExchangeRatesDataProvider()
 		return nil

--- a/pkg/exchangerates/exchange_rates_data_provider_container_test.go
+++ b/pkg/exchangerates/exchange_rates_data_provider_container_test.go
@@ -1,0 +1,43 @@
+package exchangerates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mayswind/ezbookkeeping/pkg/errs"
+	"github.com/mayswind/ezbookkeeping/pkg/settings"
+)
+
+func TestInitializeExchangeRatesDataSource_ArgentinaDatosDataSource(t *testing.T) {
+	config := &settings.Config{
+		ExchangeRatesDataSource:                 settings.ArgentinaDatosDataSource,
+		ExchangeRatesArgentinaDatosExchangeHouse: "blue",
+		ExchangeRatesArgentinaDatosRateType:     settings.ArgentinaDatosRateTypeSell,
+	}
+
+	err := InitializeExchangeRatesDataSource(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, Container.current)
+}
+
+func TestInitializeExchangeRatesDataSource_ArgentinaDatosEmptyExchangeHouse(t *testing.T) {
+	config := &settings.Config{
+		ExchangeRatesDataSource:             settings.ArgentinaDatosDataSource,
+		ExchangeRatesArgentinaDatosRateType: settings.ArgentinaDatosRateTypeSell,
+	}
+
+	err := InitializeExchangeRatesDataSource(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, Container.current)
+}
+
+func TestInitializeExchangeRatesDataSource_ArgentinaDatosInvalidExchangeHouse(t *testing.T) {
+	config := &settings.Config{
+		ExchangeRatesDataSource:                 settings.ArgentinaDatosDataSource,
+		ExchangeRatesArgentinaDatosExchangeHouse: "invalid-house",
+	}
+
+	err := InitializeExchangeRatesDataSource(config)
+	assert.Equal(t, errs.ErrInvalidExchangeRatesDataSource, err)
+}

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -159,7 +159,14 @@ const (
 	SwissNationalBankDataSource        string = "swiss_national_bank"
 	NationalBankOfUkraineDataSource    string = "national_bank_of_ukraine"
 	CentralBankOfUzbekistanDataSource  string = "central_bank_of_uzbekistan"
+	ArgentinaDatosDataSource           string = "argentina_datos"
 	UserCustomExchangeRatesDataSource  string = "user_custom"
+)
+
+// ArgentinaDatos exchange rates data source settings
+const (
+	ArgentinaDatosRateTypeBuy  string = "buy"
+	ArgentinaDatosRateTypeSell string = "sell"
 )
 
 const (
@@ -472,6 +479,8 @@ type Config struct {
 	ExchangeRatesRequestTimeoutExceedDefaultValue bool
 	ExchangeRatesProxy                            string
 	ExchangeRatesSkipTLSVerify                    bool
+	ExchangeRatesArgentinaDatosExchangeHouse      string
+	ExchangeRatesArgentinaDatosRateType           string
 }
 
 // LoadConfiguration loads setting config from given config file path
@@ -1266,6 +1275,7 @@ func loadExchangeRatesConfiguration(config *Config, configFile *ini.File, sectio
 		dataSource == SwissNationalBankDataSource ||
 		dataSource == NationalBankOfUkraineDataSource ||
 		dataSource == CentralBankOfUzbekistanDataSource ||
+		dataSource == ArgentinaDatosDataSource ||
 		dataSource == UserCustomExchangeRatesDataSource {
 		config.ExchangeRatesDataSource = dataSource
 	} else {
@@ -1280,6 +1290,14 @@ func loadExchangeRatesConfiguration(config *Config, configFile *ini.File, sectio
 	}
 
 	config.ExchangeRatesSkipTLSVerify = getConfigItemBoolValue(configFile, sectionName, "skip_tls_verify", false)
+
+	config.ExchangeRatesArgentinaDatosExchangeHouse = getConfigItemStringValue(configFile, sectionName, "argentina_datos_exchange_house")
+	config.ExchangeRatesArgentinaDatosRateType = getConfigItemStringValue(configFile, sectionName, "argentina_datos_rate_type", ArgentinaDatosRateTypeSell)
+
+	if config.ExchangeRatesArgentinaDatosRateType != ArgentinaDatosRateTypeBuy &&
+		config.ExchangeRatesArgentinaDatosRateType != ArgentinaDatosRateTypeSell {
+		config.ExchangeRatesArgentinaDatosRateType = ArgentinaDatosRateTypeSell
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add `argentina_datos` as a dedicated HTTP exchange rates datasource using the public ArgentinaDatos API
- Map config `buy`/`sell` to API fields `compra`/`venta`, with base currency ARS and USD rate as `1 / ars_per_usd`
- Register the datasource in `InitializeExchangeRatesDataSource`, document ini settings, and add unit/container tests

## Test plan
- [x] `go test ./pkg/exchangerates/ -run ArgentinaDatos -v`
- [x] `go test ./pkg/exchangerates/ -run InitializeExchangeRatesDataSource_ArgentinaDatos -v`
- [x] `BUILD_PIPELINE=1 go test ./pkg/exchangerates/... -count=1`
- [ ] Enable `data_source = argentina_datos` locally and verify latest USD rate fetch in a running instance (optional manual check)


Made with [Cursor](https://cursor.com)