### PR TITLE
Truncate overly long transaction descriptions on import

### DIFF
--- a/pkg/converters/converter/data_table_transaction_data_importer.go
+++ b/pkg/converters/converter/data_table_transaction_data_importer.go
@@ -368,6 +368,12 @@ func (c *DataTableTransactionDataImporter) ParseImportedData(ctx core.Context, u
 			description = dataRow.GetData(datatable.TRANSACTION_DATA_TABLE_PAYEE)
 		}
 
+		// The comment column in the database has a fixed maximum length. Truncate an
+		// overly long description here so that a single long value (common in imported
+		// bank statement memos) does not make the whole import fail with an opaque
+		// database error.
+		description = utils.SubString(description, 0, models.MaximumCommentLengthOfTransaction)
+
 		transaction := &models.ImportTransaction{
 			Transaction: &models.Transaction{
 				Uid:                  user.Uid,

--- a/pkg/converters/default/default_transaction_data_plain_text_converter_test.go
+++ b/pkg/converters/default/default_transaction_data_plain_text_converter_test.go
@@ -1,8 +1,10 @@
 package _default
 
 import (
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 
@@ -466,6 +468,29 @@ func TestDefaultTransactionDataCSVFileConverterParseImportedData_ParseDescriptio
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allNewTransactions))
 	assert.Equal(t, "foo    bar\t#test", allNewTransactions[0].Comment)
+}
+
+func TestDefaultTransactionDataCSVFileConverterParseImportedData_TruncateLongDescription(t *testing.T) {
+	importer := DefaultTransactionDataCSVFileConverter
+	context := core.NewNullContext()
+
+	user := &models.User{
+		Uid:             1234567890,
+		DefaultCurrency: "CNY",
+	}
+
+	// A description longer than the database comment limit. A multi-byte rune is used
+	// to ensure the truncation counts characters (runes), not bytes, and that a single
+	// overly long value does not abort the whole import with an opaque database error.
+	longDescription := strings.Repeat("ä", models.MaximumCommentLengthOfTransaction+45)
+
+	allNewTransactions, _, _, _, _, _, err := importer.ParseImportedData(context, user, []byte("Time,Type,Sub Category,Account,Amount,Account2,Account2 Amount,Description\n"+
+		"2024-09-01 12:34:56,Expense,Test Category,Test Account,123.45,,,"+longDescription), time.UTC, converter.DefaultImporterOptions, nil, nil, nil, nil, nil)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(allNewTransactions))
+	assert.Equal(t, models.MaximumCommentLengthOfTransaction, utf8.RuneCountInString(allNewTransactions[0].Comment))
+	assert.Equal(t, strings.Repeat("ä", models.MaximumCommentLengthOfTransaction), allNewTransactions[0].Comment)
 }
 
 func TestDefaultTransactionDataCSVFileConverterParseImportedData_MissingFileHeader(t *testing.T) {

--- a/pkg/models/transaction.go
+++ b/pkg/models/transaction.go
@@ -13,6 +13,9 @@ import (
 const MaximumTagsCountOfTransaction = 10
 const MaximumPicturesCountOfTransaction = 10
 
+// MaximumCommentLengthOfTransaction represents the maximum length of transaction comment stored in database
+const MaximumCommentLengthOfTransaction = 255
+
 // TransactionType represents transaction type
 type TransactionType byte
 


### PR DESCRIPTION
### Problem

When importing transactions (e.g. a CSV / the native ezBookkeeping export format), a single transaction whose description exceeds the database limit makes the **entire** import fail. The user only sees a generic "Operation failed" message, with no indication of the offending row.

The comment column is declared as `VARCHAR(255)` (`pkg/models/transaction.go`), and the API create/modify requests already enforce `binding:"max=255"`. The import path, however, assigns the description straight to `Comment` without any length check:

```go
Comment: description,
```

so an over-length value only fails deep in the database with:

```
pq: value too long for type character varying(255) (22001)
```

This is easy to hit with real-world data — imported bank-statement memos (structured SEPA purpose fields, mandate references, etc.) are frequently longer than 255 characters.

### Fix

Truncate the description to the maximum comment length before building the transaction, mirroring the existing precedent in `pkg/services/tokens.go` where the user-agent is clamped with `utils.SubString(userAgent, 0, models.TokenMaxUserAgentLength)`.

- New constant `models.MaximumCommentLengthOfTransaction = 255` (next to the existing `MaximumTagsCountOfTransaction` / `MaximumPicturesCountOfTransaction`).
- `utils.SubString` is rune-based, so truncation counts characters, not bytes — matching how `VARCHAR(255)` counts.

With this change a long memo is silently shortened to fit instead of aborting the whole import.

### Test

Added `..._TruncateLongDescription` to the default plain-text converter tests: it imports a row whose description is longer than the limit (using a multi-byte rune) and asserts the resulting `Comment` is exactly 255 runes and the import succeeds.

```
ok  github.com/mayswind/ezbookkeeping/pkg/converters/default
ok  github.com/mayswind/ezbookkeeping/pkg/converters/converter
ok  github.com/mayswind/ezbookkeeping/pkg/models
```
`gofmt` and `go vet` clean.
