### PR TITLE
Validate overly long transaction descriptions before import instead of aborting

### DIFF
--- a/src/models/imported_transaction.ts
+++ b/src/models/imported_transaction.ts
@@ -1,4 +1,5 @@
 import { TransactionType } from '@/core/transaction.ts';
+import { TRANSACTION_MAX_COMMENT_LENGTH } from '@/consts/transaction.ts';
 
 import type { TransactionCreateRequest, TransactionGeoLocationResponse } from './transaction.ts';
 
@@ -93,6 +94,10 @@ export class ImportTransaction implements ImportTransactionResponse {
                     return false;
                 }
             }
+        }
+
+        if (this.comment && this.comment.length > TRANSACTION_MAX_COMMENT_LENGTH) {
+            return false;
         }
 
         return true;

--- a/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
+++ b/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
@@ -302,12 +302,20 @@
             </div>
         </template>
         <template #item.comment="{ item }">
-            <span v-if="editingTransaction !== item">{{ item.comment || '' }}</span>
+            <template v-if="editingTransaction !== item">
+                <span v-if="!item.comment || item.comment.length <= TRANSACTION_MAX_COMMENT_LENGTH">{{ item.comment || '' }}</span>
+                <div class="text-error font-italic" v-else>
+                    <v-icon class="me-1" :icon="mdiAlertOutline"/>
+                    <span>{{ item.comment }}</span>
+                </div>
+            </template>
             <div v-if="editingTransaction === item">
                 <v-text-field style="width: 200px" type="text"
                               density="compact" variant="plain"
                               persistent-placeholder
                               :placeholder="tt('Description')"
+                              :counter="TRANSACTION_MAX_COMMENT_LENGTH"
+                              :rules="[checkImportCommentLength]"
                               :disabled="!!disabled"
                               v-model="item.comment" />
             </div>
@@ -427,6 +435,8 @@ import { CategoryType } from '@/core/category.ts';
 import { TransactionType } from '@/core/transaction.ts';
 import { KnownFileType } from '@/core/file.ts';
 import { ImportTransactionColumnType } from '@/core/import_transaction.ts';
+
+import { TRANSACTION_MAX_COMMENT_LENGTH } from '@/consts/transaction.ts';
 
 import { Account, type CategorizedAccountWithDisplayBalance } from '@/models/account.ts';
 import type { TransactionCategory } from '@/models/transaction_category.ts';
@@ -1341,6 +1351,16 @@ function isTagValid(tagIds: string[], tagIndex: number): boolean {
 
     const tagId = tagIds[tagIndex];
     return !!allTagsMap.value[tagId];
+}
+
+function checkImportCommentLength(comment: string): boolean | string {
+    if (comment && comment.length > TRANSACTION_MAX_COMMENT_LENGTH) {
+        return tt('format.misc.charactersOverLimit', {
+            count: formatNumberToLocalizedNumerals(comment.length - TRANSACTION_MAX_COMMENT_LENGTH)
+        });
+    }
+
+    return true;
 }
 
 function getDisplayDateTime(transaction: ImportTransaction): string {

--- a/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
+++ b/src/views/desktop/transactions/import/tabs/ImportTransactionCheckDataTab.vue
@@ -304,7 +304,8 @@
         <template #item.comment="{ item }">
             <template v-if="editingTransaction !== item">
                 <span v-if="!item.comment || item.comment.length <= TRANSACTION_MAX_COMMENT_LENGTH">{{ item.comment || '' }}</span>
-                <div class="text-error font-italic" v-else>
+                <div class="text-error font-italic" v-else-if="item.comment && item.comment.length > TRANSACTION_MAX_COMMENT_LENGTH">
+                    <v-tooltip activator="parent">{{ getTransactionDescriptionTooltip(item) }}</v-tooltip>
                     <v-icon class="me-1" :icon="mdiAlertOutline"/>
                     <span>{{ item.comment }}</span>
                 </div>
@@ -314,10 +315,12 @@
                               density="compact" variant="plain"
                               persistent-placeholder
                               :placeholder="tt('Description')"
-                              :counter="TRANSACTION_MAX_COMMENT_LENGTH"
-                              :rules="[checkImportCommentLength]"
                               :disabled="!!disabled"
-                              v-model="item.comment" />
+                              v-model="item.comment">
+                    <v-tooltip activator="parent" v-if="item.comment && item.comment.length > TRANSACTION_MAX_COMMENT_LENGTH">
+                        {{ getTransactionDescriptionTooltip(item) }}
+                    </v-tooltip>
+                </v-text-field>
             </div>
         </template>
         <template #bottom>
@@ -1353,16 +1356,6 @@ function isTagValid(tagIds: string[], tagIndex: number): boolean {
     return !!allTagsMap.value[tagId];
 }
 
-function checkImportCommentLength(comment: string): boolean | string {
-    if (comment && comment.length > TRANSACTION_MAX_COMMENT_LENGTH) {
-        return tt('format.misc.charactersOverLimit', {
-            count: formatNumberToLocalizedNumerals(comment.length - TRANSACTION_MAX_COMMENT_LENGTH)
-        });
-    }
-
-    return true;
-}
-
 function getDisplayDateTime(transaction: ImportTransaction): string {
     const dateTime = parseDateTimeFromUnixTimeWithTimezoneOffset(transaction.time, transaction.utcOffset)
     return formatDateTimeToLongDateTime(dateTime);
@@ -1563,6 +1556,16 @@ function getCurrentInvalidTagNames(): NameValue[] {
     }
 
     return invalidTags;
+}
+
+function getTransactionDescriptionTooltip(transaction: ImportTransaction): string {
+    if (transaction.comment && transaction.comment.length > TRANSACTION_MAX_COMMENT_LENGTH) {
+        return tt('format.misc.charactersOverLimit', {
+            count: formatNumberToLocalizedNumerals(transaction.comment.length - TRANSACTION_MAX_COMMENT_LENGTH)
+        });
+    } else {
+        return '';
+    }
 }
 
 function getAllOriginalTagNames(): NameValue[] {


### PR DESCRIPTION
## Summary

Follow-up to #631, implementing the approach @mayswind preferred there: instead of silently truncating overly long descriptions on import, this **notifies the user before the import** and lets them fix the affected rows.

When an imported transaction's description exceeds `TRANSACTION_MAX_COMMENT_LENGTH` (255), it is now flagged as **invalid** in the check-data step. That plugs into the existing validation UI:

- the row is highlighted like any other invalid row and is included in **"Select All Invalid Items"**;
- the description cell shows the offending text in the error style with an alert icon;
- when editing the description inline, the field shows a **character counter** and an **"{n} over" hint**, consistent with the transaction edit dialog (`format.misc.charactersOverLimit`).

So the user sees exactly which rows are too long and can shorten them before importing, rather than having the whole import fail with an opaque `varchar(255)` database error.

## Changes

- `models/imported_transaction.ts` — `isTransactionValid()` returns `false` when the comment exceeds the limit.
- `ImportTransactionCheckDataTab.vue` — error styling + alert icon for over-limit descriptions in read mode; `:counter` + validation rule in edit mode. Reuses the existing `format.misc.charactersOverLimit` i18n key (no new strings).

No backend changes, no automatic truncation.

## Verification

`vue-tsc --noEmit` and `eslint` on the changed files both pass.

This supersedes #631, which I'll close in favor of this PR.
