### PR TITLE
change TWD fraction from 2 to 0

### DIFF
--- a/src/consts/currency.ts
+++ b/src/consts/currency.ts
@@ -1110,7 +1110,7 @@ export const ALL_CURRENCIES: Record<string, CurrencyInfo> = {
     },
     'TWD': { // New Taiwan Dollar
         code: 'TWD',
-        fraction: 2,
+        fraction: 0,
         symbol: {
             normal: 'NT$'
         },


### PR DESCRIPTION
## Summary

Change TWD fraction digits from `2` to `0`.

```diff
- fraction: 2,
+ fraction: 0,
```

This matches common TWD usage, where amounts are typically displayed without decimal places.
