### PR TITLE
Receipt recognition: itemized breakdown option, PDF support, and a discoverable mobile entry

### DIFF
--- a/conf/ezbookkeeping.ini
+++ b/conf/ezbookkeeping.ini
@@ -168,6 +168,9 @@ transaction_from_ai_text_recognition = false
 # Set to true to enable creating transactions from AI image recognition results, requires "llm_provider" and its related model id to be configured properly in "llm_image_recognition" section
 transaction_from_ai_image_recognition = false
 
+# Set to true to include an itemized breakdown of every receipt line item in the recognized transaction description (requires image recognition to be enabled)
+receipt_image_recognition_include_items = false
+
 # Maximum allowed AI recognition picture file size (1 - 4294967295 bytes)
 max_ai_recognition_picture_size = 10485760
 

--- a/pkg/api/large_language_models.go
+++ b/pkg/api/large_language_models.go
@@ -200,7 +200,7 @@ func (a *LargeLanguageModelsApi) RecognizeReceiptImageHandler(c *core.WebContext
 	}
 
 	fileExtension := utils.GetFileNameExtension(imageFiles[0].Filename)
-	contentType := utils.GetImageContentType(fileExtension)
+	contentType := utils.GetReceiptFileContentType(fileExtension)
 
 	if contentType == "" {
 		log.Warnf(c, "[large_language_models.RecognizeReceiptImageHandler] the file extension \"%s\" of image in request is not supported for user \"uid:%d\"", fileExtension, uid)
@@ -244,6 +244,7 @@ func (a *LargeLanguageModelsApi) RecognizeReceiptImageHandler(c *core.WebContext
 		"AllAccountNames":          strings.Join(accountNames, "\n"),
 		"AllTagNames":              strings.Join(tagNames, "\n"),
 		"AdditionalNotes":          "",
+		"IncludeReceiptItems":      a.CurrentConfig().ReceiptImageRecognitionIncludeItems,
 	}
 
 	var bodyBuffer bytes.Buffer

--- a/pkg/errs/system.go
+++ b/pkg/errs/system.go
@@ -4,11 +4,12 @@ import "net/http"
 
 // Error codes related to transaction categories
 var (
-	ErrSystemError           = NewSystemError(SystemSubcategoryDefault, 0, http.StatusInternalServerError, "system error")
-	ErrApiNotFound           = NewSystemError(SystemSubcategoryDefault, 1, http.StatusNotFound, "api not found")
-	ErrMethodNotAllowed      = NewSystemError(SystemSubcategoryDefault, 2, http.StatusMethodNotAllowed, "method not allowed")
-	ErrNotImplemented        = NewSystemError(SystemSubcategoryDefault, 3, http.StatusNotImplemented, "not implemented")
-	ErrSystemIsBusy          = NewSystemError(SystemSubcategoryDefault, 4, http.StatusServiceUnavailable, "system is busy")
-	ErrNotSupported          = NewSystemError(SystemSubcategoryDefault, 5, http.StatusBadRequest, "not supported")
-	ErrImageTypeNotSupported = NewSystemError(SystemSubcategoryDefault, 6, http.StatusBadRequest, "image type not supported")
+	ErrSystemError                      = NewSystemError(SystemSubcategoryDefault, 0, http.StatusInternalServerError, "system error")
+	ErrApiNotFound                      = NewSystemError(SystemSubcategoryDefault, 1, http.StatusNotFound, "api not found")
+	ErrMethodNotAllowed                 = NewSystemError(SystemSubcategoryDefault, 2, http.StatusMethodNotAllowed, "method not allowed")
+	ErrNotImplemented                   = NewSystemError(SystemSubcategoryDefault, 3, http.StatusNotImplemented, "not implemented")
+	ErrSystemIsBusy                     = NewSystemError(SystemSubcategoryDefault, 4, http.StatusServiceUnavailable, "system is busy")
+	ErrNotSupported                     = NewSystemError(SystemSubcategoryDefault, 5, http.StatusBadRequest, "not supported")
+	ErrImageTypeNotSupported            = NewSystemError(SystemSubcategoryDefault, 6, http.StatusBadRequest, "image type not supported")
+	ErrPdfTypeNotSupportedByLLMProvider = NewSystemError(SystemSubcategoryDefault, 7, http.StatusBadRequest, "pdf type not supported by the large language model provider")
 )

--- a/pkg/llm/provider/anthropic/anthropic_common_compatible_large_language_model_adapter.go
+++ b/pkg/llm/provider/anthropic/anthropic_common_compatible_large_language_model_adapter.go
@@ -186,11 +186,15 @@ func (p *CommonAnthropicMessagesAPILargeLanguageModelAdapter) buildJsonRequestBo
 	if len(request.UserPrompt) > 0 {
 		if request.UserPromptType == data.LARGE_LANGUAGE_MODEL_REQUEST_PROMPT_TYPE_IMAGE_URL {
 			imageBase64Data := base64.StdEncoding.EncodeToString(request.UserPrompt)
+			blockType := "image"
+			if request.UserPromptContentType == "application/pdf" {
+				blockType = "document"
+			}
 			messagesRequest.Messages = append(messagesRequest.Messages, &AnthropicMessagesRequestMessage[[]*AnthropicMessagesRequestImageBlockParam]{
 				Role: AnthropicMessageRoleUser,
 				Content: []*AnthropicMessagesRequestImageBlockParam{
 					{
-						Type: "image",
+						Type: blockType,
 						Source: &AnthropicMessagesRequestBase64ImageSource{
 							Data:      imageBase64Data,
 							MediaType: request.UserPromptContentType,

--- a/pkg/llm/provider/lmstudio/lm_studio_large_language_model_adapter.go
+++ b/pkg/llm/provider/lmstudio/lm_studio_large_language_model_adapter.go
@@ -128,6 +128,10 @@ func (p *LMStudioLargeLanguageModelAdapter) buildJsonRequestBody(c core.Context,
 
 	if len(request.UserPrompt) > 0 {
 		if request.UserPromptType == data.LARGE_LANGUAGE_MODEL_REQUEST_PROMPT_TYPE_IMAGE_URL {
+			if request.UserPromptContentType == "application/pdf" {
+				return nil, errs.ErrPdfTypeNotSupportedByLLMProvider
+			}
+
 			imageBase64Data := "data:" + request.UserPromptContentType + ";base64," + base64.StdEncoding.EncodeToString(request.UserPrompt)
 			chatRequest.Input = append(chatRequest.Input, &LMStudioChatRequestInput{
 				Type:    "image",

--- a/pkg/llm/provider/ollama/ollama_large_language_model_adapter.go
+++ b/pkg/llm/provider/ollama/ollama_large_language_model_adapter.go
@@ -134,6 +134,10 @@ func (p *OllamaLargeLanguageModelAdapter) buildJsonRequestBody(c core.Context, u
 
 	if len(request.UserPrompt) > 0 {
 		if request.UserPromptType == data.LARGE_LANGUAGE_MODEL_REQUEST_PROMPT_TYPE_IMAGE_URL {
+			if request.UserPromptContentType == "application/pdf" {
+				return nil, errs.ErrPdfTypeNotSupportedByLLMProvider
+			}
+
 			imageBase64Data := base64.StdEncoding.EncodeToString(request.UserPrompt)
 			chatRequest.Messages = append(chatRequest.Messages, &OllamaChatRequestMessage{
 				Role:   OllamaMessageRoleUser,

--- a/pkg/llm/provider/openai/openai_common_compatible_large_language_model_adapter.go
+++ b/pkg/llm/provider/openai/openai_common_compatible_large_language_model_adapter.go
@@ -180,6 +180,10 @@ func (p *CommonOpenAIChatCompletionsAPILargeLanguageModelAdapter) buildJsonReque
 
 	if len(request.UserPrompt) > 0 {
 		if request.UserPromptType == data.LARGE_LANGUAGE_MODEL_REQUEST_PROMPT_TYPE_IMAGE_URL {
+			if request.UserPromptContentType == "application/pdf" {
+				return nil, errs.ErrPdfTypeNotSupportedByLLMProvider
+			}
+
 			imageBase64Data := "data:" + request.UserPromptContentType + ";base64," + base64.StdEncoding.EncodeToString(request.UserPrompt)
 			chatCompletionsRequest.Messages = append(chatCompletionsRequest.Messages, &OpenAIChatCompletionsRequestMessage[[]*OpenAIChatCompletionsRequestImageContent]{
 				Role: OpenAIMessageRoleUser,

--- a/pkg/llm/provider/openai/openai_common_responses_api_large_language_model_adapter.go
+++ b/pkg/llm/provider/openai/openai_common_responses_api_large_language_model_adapter.go
@@ -193,6 +193,10 @@ func (p *CommonOpenAIResponsesAPILargeLanguageModelAdapter) buildJsonRequestBody
 
 	if len(request.UserPrompt) > 0 {
 		if request.UserPromptType == data.LARGE_LANGUAGE_MODEL_REQUEST_PROMPT_TYPE_IMAGE_URL {
+			if request.UserPromptContentType == "application/pdf" {
+				return nil, errs.ErrPdfTypeNotSupportedByLLMProvider
+			}
+
 			imageBase64Data := "data:" + request.UserPromptContentType + ";base64," + base64.StdEncoding.EncodeToString(request.UserPrompt)
 			responsesRequest.Input = append(responsesRequest.Input, &OpenAIResponsesRequestInputMessage[[]*OpenAIResponsesRequestInputContent]{
 				Role: OpenAIMessageRoleUser,

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -359,9 +359,10 @@ type Config struct {
 	WebDAVConfig        *WebDAVConfig
 
 	// Large Language Model
-	TransactionFromAITextRecognition  bool
-	TransactionFromAIImageRecognition bool
-	MaxAIRecognitionPictureFileSize   uint32
+	TransactionFromAITextRecognition    bool
+	TransactionFromAIImageRecognition   bool
+	ReceiptImageRecognitionIncludeItems bool
+	MaxAIRecognitionPictureFileSize     uint32
 
 	// Large Language Model for Transaction Text Recognition
 	TextRecognitionLLMConfig *LLMConfig
@@ -883,6 +884,7 @@ func loadStorageConfiguration(config *Config, configFile *ini.File, sectionName 
 func loadLLMGlobalConfiguration(config *Config, configFile *ini.File, sectionName string) error {
 	config.TransactionFromAITextRecognition = getConfigItemBoolValue(configFile, sectionName, "transaction_from_ai_text_recognition", false)
 	config.TransactionFromAIImageRecognition = getConfigItemBoolValue(configFile, sectionName, "transaction_from_ai_image_recognition", false)
+	config.ReceiptImageRecognitionIncludeItems = getConfigItemBoolValue(configFile, sectionName, "receipt_image_recognition_include_items", false)
 	config.MaxAIRecognitionPictureFileSize = getConfigItemUint32Value(configFile, sectionName, "max_ai_recognition_picture_size", defaultAIRecognitionPictureMaxSize)
 
 	return nil

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -15,9 +15,29 @@ var imageFileExtensionContentTypeMap = map[string]string{
 	"webp": "image/webp",
 }
 
+var receiptFileExtensionContentTypeMap = map[string]string{
+	"jpg":  "image/jpeg",
+	"jpeg": "image/jpeg",
+	"png":  "image/png",
+	"gif":  "image/gif",
+	"webp": "image/webp",
+	"pdf":  "application/pdf",
+}
+
 // GetImageContentType returns the content type of specified image file extension or returns empty when the file extension is not image or not supported
 func GetImageContentType(fileExtension string) string {
 	contentType, exists := imageFileExtensionContentTypeMap[fileExtension]
+
+	if !exists {
+		return ""
+	}
+
+	return contentType
+}
+
+// GetReceiptFileContentType returns the content type of a supported receipt file (image or PDF) extension, or returns empty when the file extension is not supported
+func GetReceiptFileContentType(fileExtension string) string {
+	contentType, exists := receiptFileExtensionContentTypeMap[fileExtension]
 
 	if !exists {
 		return ""

--- a/src/components/mobile/AIImageRecognitionSheet.vue
+++ b/src/components/mobile/AIImageRecognitionSheet.vue
@@ -20,7 +20,8 @@
                 <img :src="imageSrc" v-if="imageSrc" />
                 <div class="image-container-background display-flex justify-content-center align-items-center text-align-center padding-horizontal" v-if="!imageSrc">
                     <div class="display-inline-flex flex-direction-column" v-if="!loading">
-                        <span>{{ tt('Click here to select a receipt or transaction image') }}</span>
+                        <span v-if="selectedPdfName && imageFile">{{ selectedPdfName }}</span>
+                        <span v-else>{{ tt('Click here to select a receipt or transaction image') }}</span>
                         <small class="margin-top-half">{{ tt('Uploaded image and personal data will be sent to the large language model, please be aware of potential privacy risks.') }}</small>
                     </div>
                     <span v-else-if="loading">{{ tt('Loading image...') }}</span>
@@ -28,7 +29,7 @@
             </div>
         </f7-page-content>
 
-        <input ref="imageInput" type="file" style="display: none" :accept="`${SUPPORTED_IMAGE_EXTENSIONS};capture=camera`" @change="openImage($event)" />
+        <input ref="imageInput" type="file" style="display: none" :accept="SUPPORTED_RECEIPT_RECOGNITION_EXTENSIONS" @change="openImage($event)" />
     </f7-sheet>
 </template>
 
@@ -43,7 +44,7 @@ import { useTransactionsStore } from '@/stores/transaction.ts';
 
 import { ImageUploadQualityType } from '@/core/image.ts';
 import { KnownFileType } from '@/core/file.ts';
-import { SUPPORTED_IMAGE_EXTENSIONS } from '@/consts/file.ts';
+import { SUPPORTED_RECEIPT_RECOGNITION_EXTENSIONS } from '@/consts/file.ts';
 
 import type { RecognizedTransactionResponse } from '@/models/large_language_model.ts';
 
@@ -77,11 +78,22 @@ const recognizing = ref<boolean>(false);
 const cancelRecognizingUuid = ref<string | undefined>(undefined);
 const imageFile = ref<File | null>(null);
 const imageSrc = ref<string | undefined>(undefined);
+const selectedPdfName = ref<string>('');
 
 function loadImage(image: Blob): void {
     loading.value = true;
     imageFile.value = null;
     imageSrc.value = undefined;
+    selectedPdfName.value = '';
+
+    const selectedFile = image as File;
+
+    if (image.type === 'application/pdf' || /\.pdf$/i.test(selectedFile.name || '')) {
+        imageFile.value = selectedFile; // PDFs are sent as-is; the backend forwards the document to the model
+        selectedPdfName.value = selectedFile.name || 'receipt.pdf';
+        loading.value = false;
+        return;
+    }
 
     compressJpgImageByQuality(image, ImageUploadQualityType.HD720P).then(blob => {
         imageFile.value = KnownFileType.JPG.createFileFromBlob(blob, "image");

--- a/src/consts/file.ts
+++ b/src/consts/file.ts
@@ -2,6 +2,9 @@ import type { ImportFileCategoryAndTypes } from '@/core/file.ts';
 
 export const SUPPORTED_IMAGE_EXTENSIONS: string = '.jpg,.jpeg,.png,.gif,.webp';
 
+// Receipt/transaction image recognition also accepts PDF documents (some merchants issue PDF receipts)
+export const SUPPORTED_RECEIPT_RECOGNITION_EXTENSIONS: string = SUPPORTED_IMAGE_EXTENSIONS + ',.pdf';
+
 export const DEFAULT_DOCUMENT_LANGUAGE_FOR_IMPORT_FILE: string = 'en';
 export const SUPPORTED_DOCUMENT_LANGUAGES_FOR_IMPORT_FILE: Record<string, string> = {
     DEFAULT_DOCUMENT_LANGUAGE_FOR_IMPORT_FILE: DEFAULT_DOCUMENT_LANGUAGE_FOR_IMPORT_FILE,

--- a/src/views/desktop/transactions/list/dialogs/AIImageRecognitionDialog.vue
+++ b/src/views/desktop/transactions/list/dialogs/AIImageRecognitionDialog.vue
@@ -30,6 +30,7 @@
                         <span class="text-title-medium font-weight-bold pa-2" v-else-if="!loading && isDragOver">{{ tt('Release to load image') }}</span>
                         <span class="text-title-medium font-weight-bold pa-2" v-else-if="loading">{{ tt('Loading image...') }}</span>
                         <span class="text-title-medium font-weight-bold pa-2" v-else-if="recognizing">{{ tt('AI can make mistakes. Check important info.') }}</span>
+                        <span class="text-title-medium font-weight-bold pa-2" v-else-if="!loading && !recognizing && selectedPdfName && imageFile">{{ selectedPdfName }}</span>
                     </div>
                     <v-img :class="{ 'cursor-pointer': !loading && !recognizing && !isDragOver, 'h-100': true }"
                            :src="imageSrc" @click="showOpenImageDialog">
@@ -44,7 +45,7 @@
     </v-dialog>
 
     <snack-bar ref="snackbar" />
-    <input ref="imageInput" type="file" style="display: none" :accept="SUPPORTED_IMAGE_EXTENSIONS" @change="openImage($event)" />
+    <input ref="imageInput" type="file" style="display: none" :accept="SUPPORTED_RECEIPT_RECOGNITION_EXTENSIONS" @change="openImage($event)" />
 </template>
 
 <script setup lang="ts">
@@ -60,7 +61,7 @@ import { useTransactionsStore } from '@/stores/transaction.ts';
 import { ImageUploadQualityType } from '@/core/image.ts';
 import { KnownFileType } from '@/core/file.ts';
 import { ThemeType } from '@/core/theme.ts';
-import { SUPPORTED_IMAGE_EXTENSIONS } from '@/consts/file.ts';
+import { SUPPORTED_RECEIPT_RECOGNITION_EXTENSIONS } from '@/consts/file.ts';
 
 import type { RecognizedTransactionResponse } from '@/models/large_language_model.ts';
 
@@ -93,6 +94,7 @@ const recognizing = ref<boolean>(false);
 const cancelRecognizingUuid = ref<string | undefined>(undefined);
 const imageFile = ref<File | null>(null);
 const imageSrc = ref<string | undefined>(undefined);
+const selectedPdfName = ref<string>('');
 const isDragOver = ref<boolean>(false);
 
 const isDarkMode = computed<boolean>(() => theme.global.name.value === ThemeType.Dark);
@@ -101,6 +103,14 @@ function loadImage(file: File): void {
     loading.value = true;
     imageFile.value = null;
     imageSrc.value = undefined;
+    selectedPdfName.value = '';
+
+    if (file.type === 'application/pdf' || /\.pdf$/i.test(file.name || '')) {
+        imageFile.value = file; // PDFs are sent as-is; the backend forwards the document to the model
+        selectedPdfName.value = file.name || 'receipt.pdf';
+        loading.value = false;
+        return;
+    }
 
     compressJpgImageByQuality(file, ImageUploadQualityType.HD720P).then(blob => {
         imageFile.value = KnownFileType.JPG.createFileFromBlob(blob, "image");

--- a/src/views/mobile/HomePage.vue
+++ b/src/views/mobile/HomePage.vue
@@ -2,6 +2,10 @@
     <f7-page ptr @ptr:refresh="reload" @page:afterin="onPageAfterIn">
         <f7-navbar>
             <f7-nav-title :title="tt('global.app.title')"></f7-nav-title>
+            <f7-nav-right v-if="isTransactionFromAIImageRecognitionEnabled()">
+                <f7-link icon-f7="wand_stars" :aria-label="tt('AI Image Recognition')"
+                         @click="showAIReceiptImageRecognitionSheet = true"></f7-link>
+            </f7-nav-right>
         </f7-navbar>
 
         <overview-dashboard :layout="layout" :loading="loading" @navigate="onNavigate" />

--- a/templates/prompt/receipt_image_recognition.tmpl
+++ b/templates/prompt/receipt_image_recognition.tmpl
@@ -11,11 +11,11 @@ Your task is to extract structured transaction data from images provided by the 
 {
   "type": "string (transaction type: expense | income | transfer)",
   "time": "string (transaction time, format: YYYY-MM-DD HH:mm:ss)",
-  "amount": "string (transaction amount, numeric, up to 2 decimals. For example, for an expense transaction, 12.34 represents an expense of 12.34)",
+  "amount": "string (transaction amount, numeric, up to 2 decimals)",
   "account": "string (source account name)",
   "category": "string (transaction category)",
   "tags": ["string (tag name, max 10 allowed)"],
-  "description": "string (transaction description)",
+  "description": "string (transaction description{{if .IncludeReceiptItems}}: start with the merchant/store name, then an itemized breakdown of every line item on the receipt, one item per line, in the format 'quantity x item name - price'{{end}})",
   "destination_amount": "string (destination amount, numeric, up to 2 decimals, only for transfer)",
   "destination_account": "string (destination account name, only for transfer)"
 }
@@ -24,7 +24,11 @@ Your task is to extract structured transaction data from images provided by the 
 ## Important rules
 1. Only include fields you can confidently identify.
 2. If unsure about a value, omit the field (do not guess).
+{{if .IncludeReceiptItems -}}
+3. If the image contains multiple line items, combine them into ONE transaction whose "amount" is the grand total, and list EVERY individual line item (quantity, item name, price) in the "description" field, one item per line, preserving the original item names exactly as printed.
+{{- else -}}
 3. If the image contains multiple items, please combine them into a single transaction.
+{{- end}}
 4. If the image contains no transaction information, simply return an empty JSON object.
 5. Always return valid JSON.
 


### PR DESCRIPTION
## Summary

Three related improvements to AI receipt/transaction-image recognition:

### 1. Optional itemized breakdown in the description
New `[llm]` option **`receipt_image_recognition_include_items`** (default `false`). When enabled, the receipt-image recognition prompt asks the model to place an itemized breakdown of every receipt line item (quantity, name, price) into the transaction **description**, while `amount` stays the grand total. Default behaviour is unchanged (single combined transaction).

### 2. PDF receipts
Receipt image recognition now accepts **PDF** files (`application/pdf`) in addition to images — some merchants only issue PDF receipts.
- Backend: a new `GetReceiptFileContentType` accepts pdf; **Google AI** and **Anthropic** send the document to the model (Anthropic uses a `document` content block). Providers that don't support documents (OpenAI chat/responses, Ollama, LM Studio) return a clear new error `pdf type not supported by the large language model provider` instead of sending a malformed request.
- Frontend: the recognition file picker (mobile sheet + desktop dialog) accepts `.pdf`; PDFs are sent as-is, skipping the JPG compression used for images, and the picker shows the selected file name.

### 3. Discoverable mobile entry
Receipt image recognition on mobile was only reachable via a long-press on the home "add" button. This adds a visible navbar action on the mobile home page (shown only when image recognition is enabled) so it's reachable with a regular tap.

## Testing
- `go build ./...` and `vue-tsc --noEmit` both pass.
- The itemized-breakdown prompt was verified end-to-end against Google AI (Gemini) on a live instance.
- Google AI PDF uses the existing inline-document mechanism. Anthropic/other provider paths follow the documented request shapes; maintainer testing on those providers is welcome.

## Notes / possible follow-ups
- OpenAI (chat completions `file` / responses `input_file`) PDF support could be added later; for now those providers reject PDF cleanly.
- `receipt_image_recognition_include_items` is a server config; it could alternatively be exposed as a per-user setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
